### PR TITLE
Place an (invisible) cursor at the beginning of the active list item

### DIFF
--- a/app/ghcup/BrickMain.hs
+++ b/app/ghcup/BrickMain.hs
@@ -171,7 +171,7 @@ ui dimAttrs BrickState{ appSettings = as@BrickSettings{}, ..}
           | elem Latest lTag && not lInstalled =
               withAttr "hooray"
           | otherwise = id
-        active = if b then forceAttr "active" else id
+        active = if b then putCursor "GHCup" (Location (0,0)) . forceAttr "active" else id
     in  hooray $ active $ dim
           (   marks
           <+> padLeft (Pad 2)
@@ -259,7 +259,7 @@ app attrs dimAttrs =
   , appHandleEvent  = eventHandler
   , appStartEvent   = return
   , appAttrMap      = const attrs
-  , appChooseCursor = neverShowCursor
+  , appChooseCursor = showFirstCursor
   }
 
 defaultAttributes :: Bool -> AttrMap

--- a/ghcup.cabal
+++ b/ghcup.cabal
@@ -233,7 +233,7 @@ executable ghcup
     cpp-options:   -DBRICK
     other-modules: BrickMain
     build-depends:
-      , brick         >=0.5    && <0.62
+      , brick         >=0.5    && <0.64
       , transformers  ^>=0.5
       , vector        ^>=0.12
       , vty           >=5.28.2 && <5.34

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,9 @@ extra-deps:
   - git: https://github.com/Bodigrim/tar
     commit: ac197ec7ea4838dc2b4e22b9b888b080cedf29cf
 
+  - git: https://github.com/jtdaugherty/brick.git
+    commit: b3b96cfe66dfd398d338e3feb2b6855e66a35190
+
   - IfElse-0.85@sha256:6939b94acc6a55f545f63a168a349dd2fbe4b9a7cca73bf60282db5cc6aa47d2,445
   - ascii-string-1.0.1.4@sha256:fa34f1d9ba57e8e89c0d4c9cef5e01ba32cb2d4373d13f92dcc0b531a6c6749b,2582
   - base16-bytestring-0.1.1.7@sha256:0021256a9628971c08da95cb8f4d0d72192f3bb8a7b30b55c080562d17c43dd3,2231


### PR DESCRIPTION
This change is to support screen readers which use the cursor location
to indicate the focus to the user.

Brick.putCursor is unreleased, so grab the latest version from git via extra-deps.
