### PR TITLE
Fix AlreadyInstalled error message

### DIFF
--- a/lib/GHCup/Errors.hs
+++ b/lib/GHCup/Errors.hs
@@ -138,7 +138,7 @@ data AlreadyInstalled = AlreadyInstalled Tool Version
 instance Pretty AlreadyInstalled where
   pPrint (AlreadyInstalled tool ver') =
     pPrint tool <+> text "-" <+> pPrint ver' <+> text "is already installed;"
-    <+> text "if you really want to reinstall it, you may want to run 'ghcup install cabal --force" <+> (pPrint ver' <> text "'")
+    <+> text "if you really want to reinstall it, you may want to run 'ghcup install" <+> pPrint tool <+> text "--force" <+> (pPrint ver' <> text "'")
 
 
 -- | The Directory is supposed to be empty, but wasn't.


### PR DESCRIPTION
`AlreadyInstalled` error message currently lists `cabal` regardless of which tool is already installed (e.g. `ghc`/`cabal`/`hls`/`stack`), e.g.
```
[ Warn  ] ghc-9.2.4 is already installed; if you really want to reinstall it, you may want to run 'ghcup install cabal --force 9.2.4'
[ Warn  ] cabal-3.6.2.0 is already installed; if you really want to reinstall it, you may want to run 'ghcup install cabal --force 3.6.2.0'
[ Error ] Both installation and setting the tool failed. Install error was: hls-1.8.0.0 is already installed; if you really want to reinstall it, you may want to run 'ghcup install cabal --force 1.8.0.0'
[ Warn  ] stack-2.9.1 is already installed; if you really want to reinstall it, you may want to run 'ghcup install cabal --force 2.9.1'
```