### PR TITLE
Test M1 build with new config.{guess,sub} but configure generated by autoconf-2.69

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,7 +166,7 @@ variables:
     set -Eeuo pipefail
     function runInNixShell() {
       time nix-shell $CI_PROJECT_DIR/.gitlab/shell.nix \
-        -I nixpkgs=https://github.com/angerman/nixpkgs/archive/75f7281738b.tar.gz \
+        -I nixpkgs=https://github.com/bgamari/nixpkgs/archive/37c60356e3f83c708a78a96fdd914b5ffc1f551c.tar.gz \
         --argstr system "aarch64-darwin" \
         --pure \
         --keep CI_PROJECT_DIR \

--- a/.gitlab/before_script/darwin/install_deps.sh
+++ b/.gitlab/before_script/darwin/install_deps.sh
@@ -23,10 +23,10 @@ if [ $ARCH = 'ARM64' ] ; then
 	cabal update
 	mkdir vendored
 	cd vendored
-	cabal unpack network-3.1.2.1
-	cd network*
-	autoreconf -fi
-	cd ../..
+	curl -O https://downloads.haskell.org/~ghcup/tmp/network-3.1.2.3.tar.gz
+	tar xf network-3.1.2.3.tar.gz
+	rm network-3.1.2.3.tar.gz
+	cd ..
 fi
 
 exit 0


### PR DESCRIPTION
In GitLab by @maerwald on Oct 7, 2021, 20:31

