### PR TITLE
fix link

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 # Installation
 
 GHCup makes it easy to install specific versions of GHC on GNU/Linux,
-macOS (aka Darwin), FreeBSD and Windows and can also bootstrap a fresh [Haskell developer environment](./install/#supported-tools) from scratch.
+macOS (aka Darwin), FreeBSD and Windows and can also bootstrap a fresh [Haskell developer environment](./#supported-tools) from scratch.
 It follows the UNIX philosophy of [do one thing and do it well](https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well). Similar in scope to [rustup](https://github.com/rust-lang-nursery/rustup.rs), [pyenv](https://github.com/pyenv/pyenv) and [jenv](http://www.jenv.be).
 
 ## How to install


### PR DESCRIPTION
currently resolves to: https://www.haskell.org/ghcup/install/install/#supported-tools  -> 500
this commit fixes it to https://www.haskell.org/ghcup/install/#supported-tools