### PR TITLE
Add a known mirror

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -163,6 +163,7 @@ ghcup --url-source=https://some-url/ghcup-0.0.6.yaml list
 #### Known mirrors
 
 1. [https://mirror.sjtu.edu.cn/docs/ghcup](https://mirror.sjtu.edu.cn/docs/ghcup)
+2. [https://mirrors.ustc.edu.cn/help/ghcup.html](https://mirrors.ustc.edu.cn/help/ghcup.html)
 
 ### (Pre-)Release channels
 


### PR DESCRIPTION
USTCLUG (@ustclug) has been operating a [ghcup mirror](https://mirrors.ustc.edu.cn/help/ghcup.html) for some time.

This PR adds this mirror to the list of the known mirrors in the docs.