### PR TITLE
update Ubuntu required packages: libffi6 -> libffi8ubuntu1

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -42,7 +42,7 @@ The following distro packages are required: `build-essential curl libffi-dev lib
 
 ### Linux Ubuntu
 
-The following distro packages are required: `build-essential curl libffi-dev libffi6 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5`
+The following distro packages are required: `build-essential curl libffi-dev libffi8ubuntu1 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5`
 
 ### Linux Fedora
 


### PR DESCRIPTION
I just installed ghcup on ubuntu 22.04.1 (LTS) and apt-get couldn't find `libffi6`. In addition the installer says:
> Please ensure the following distro packages are installed before continuing (you can exit ghcup and return at any time): build-essential curl libffi-dev libffi8ubuntu1 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5
So I guess these instructions are outdated regarding libffi6.