### PR TITLE
Release 0.1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Revision history for ghcup
 
+## 0.1.19.1 -- 2023-2-19
+
+* Fix GHCup on JFS/ReiserFS and other filesystem that don't support `d_type`, fixes [#766](https://github.com/haskell/ghcup-hs/issues/766)
+* Don't fail on setModificationTime, fixes [#784](https://github.com/haskell/ghcup-hs/issues/784) and many GitHub actions issues
+* Make armv7/aarch64 linux binaries more portable (built on Debian buster)
+* Improve usability on 'ghcup config add-release-channel', fixes [#751](https://github.com/haskell/ghcup-hs/issues/751)
+* Make version shortcuts work with 'ghcup set', fixes [#757](https://github.com/haskell/ghcup-hs/issues/757)
+* Don't implicitly smuggle in config options in `ghcup config set` wrt [#775](https://github.com/haskell/ghcup-hs/issues/775)
+* Fix build on unix with -ftui
+
 ## 0.1.19.0 -- 2023-1-13
 
 * restore proper support for FreeBSD and Linux armv7

--- a/ghcup.cabal
+++ b/ghcup.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               ghcup
-version:            0.1.19.0
+version:            0.1.19.1
 license:            LGPL-3.0-only
 license-file:       LICENSE
 copyright:          Julian Ospald 2020

--- a/scripts/bootstrap/bootstrap-haskell
+++ b/scripts/bootstrap/bootstrap-haskell
@@ -28,7 +28,7 @@
 
 plat="$(uname -s)"
 arch=$(uname -m)
-ghver="0.1.19.0"
+ghver="0.1.19.1"
 : "${GHCUP_BASE_URL:=https://downloads.haskell.org/~ghcup}"
 
 export GHCUP_SKIP_UPDATE_CHECK=yes

--- a/scripts/releasing/pull_release_artifacts.sh
+++ b/scripts/releasing/pull_release_artifacts.sh
@@ -18,17 +18,19 @@ done
 [ ! -e "gh-release-artifacts/${RELEASE}" ]
 
 mkdir -p "gh-release-artifacts/${RELEASE}"
+
+git archive --format=tar.gz -o "gh-release-artifacts/${RELEASE}/ghcup-${RELEASE}-src.tar.gz" --prefix="ghcup-${RELEASE}/" HEAD
+
 cd "gh-release-artifacts/${RELEASE}"
 
 # github
-gh release download $RELEASE
-
-rm test-*
+gh release download "$RELEASE"
 
 # cirrus
-curl -L -o x86_64-portbld-freebsd-ghcup-${RELEASE} \
+curl -L -o "x86_64-portbld-freebsd-ghcup-${RELEASE}" \
 	"https://api.cirrus-ci.com/v1/artifact/github/haskell/ghcup-hs/build/binaries/out/x86_64-portbld-freebsd-ghcup-${RELEASE}?branch=${RELEASE}"
 
-sha256sum *ghcup* > SHA256SUMS
+sha256sum ./*-ghcup-* > SHA256SUMS
 gpg --detach-sign -u "${SIGNER}" SHA256SUMS
 
+gh release upload "$RELEASE" "ghcup-${RELEASE}-src.tar.gz" "x86_64-portbld-freebsd-ghcup-${RELEASE}" SHA256SUMS SHA256SUMS.sig

--- a/scripts/releasing/sftp-symlink-artifacts.sh
+++ b/scripts/releasing/sftp-symlink-artifacts.sh
@@ -21,8 +21,7 @@ rm i386-linux-ghcup
 rm x86_64-apple-darwin-ghcup
 rm x86_64-linux-ghcup
 rm x86_64-mingw64-ghcup.exe
-rm x86_64-freebsd12-ghcup
-rm x86_64-freebsd13-ghcup
+rm x86_64-portbld-freebsd-ghcup
 
 symlink ${ver}/aarch64-apple-darwin-ghcup-${ver} aarch64-apple-darwin-ghcup
 symlink ${ver}/aarch64-linux-ghcup-${ver} aarch64-linux-ghcup


### PR DESCRIPTION
- [x] update version in `ghcup.cabal`
- [x] update `ghcupURL` in `GHCup.Version` if need be
- [x] add ChangeLog entry
- [x] update data/metadata submodule
- [x] create tag and let CI create draft release
- [x] upload release artifacts to downloads.haskell.org
- [x] update YAML files in ghcup-metadata with new GHCup binaries
- [x] update ghcup-hs submodule in ghcup-metadata
- [x] upload yamls to webhost.haskell.org/ghcup/data/ as well
- [x] update `ghver` in `scripts/bootstrap/bootstrap-haskell`
- [x] upload `scripts/bootstrap/bootstrap-haskell`
- [x] update top-level symlinks in downloads.haskell.org/~ghcup
- [x] publish release on github
- [x] upload to hackage