### PR TITLE
Release 0.1.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ghcup
 
-## 0.1.19.2 -- ????-??-??
+## 0.1.19.2 -- 2023-2-24
 
 * Follow-up fix for JFS/ReiserFS and other filesystem that don't support `d_type`, fixes [#787](https://github.com/haskell/ghcup-hs/issues/787)
     - the previous release had a bug that invalidated that broke it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Follow-up fix for JFS/ReiserFS and other filesystem that don't support `d_type`, fixes [#787](https://github.com/haskell/ghcup-hs/issues/787)
     - the previous release had a bug that invalidated that broke it
 * Implement 'latest-prerelease' tag wrt [#788](https://github.com/haskell/ghcup-hs/issues/788)
+* Fix 'Could not parse version of stray directory.DS_Store' warnings on macOs wrt [#797](https://github.com/haskell/ghcup-hs/issues/797)
 
 ## 0.1.19.1 -- 2023-2-19
 

--- a/scripts/bootstrap/bootstrap-haskell
+++ b/scripts/bootstrap/bootstrap-haskell
@@ -28,7 +28,7 @@
 
 plat="$(uname -s)"
 arch=$(uname -m)
-ghver="0.1.19.1"
+ghver="0.1.19.2"
 : "${GHCUP_BASE_URL:=https://downloads.haskell.org/~ghcup}"
 
 export GHCUP_SKIP_UPDATE_CHECK=yes

--- a/scripts/releasing/pull_release_artifacts.sh
+++ b/scripts/releasing/pull_release_artifacts.sh
@@ -7,6 +7,7 @@ shopt -s extglob
 
 RELEASE=$1
 SIGNER=$2
+TAG=${RELEASE/v/}
 
 echo "RELEASE: $RELEASE"
 echo "SIGNER: $SIGNER"
@@ -19,7 +20,7 @@ done
 
 mkdir -p "gh-release-artifacts/${RELEASE}"
 
-git archive --format=tar.gz -o "gh-release-artifacts/${RELEASE}/ghcup-${RELEASE}-src.tar.gz" --prefix="ghcup-${RELEASE}/" HEAD
+git archive --format=tar.gz -o "gh-release-artifacts/${RELEASE}/ghcup-${TAG}-src.tar.gz" --prefix="ghcup-${TAG}/" HEAD
 
 cd "gh-release-artifacts/${RELEASE}"
 
@@ -27,10 +28,10 @@ cd "gh-release-artifacts/${RELEASE}"
 gh release download "$RELEASE"
 
 # cirrus
-curl -L -o "x86_64-portbld-freebsd-ghcup-${RELEASE}" \
+curl -L -o "x86_64-portbld-freebsd-ghcup-${TAG}" \
 	"https://api.cirrus-ci.com/v1/artifact/github/haskell/ghcup-hs/build/binaries/out/x86_64-portbld-freebsd-ghcup-${RELEASE}?branch=${RELEASE}"
 
 sha256sum ./*-ghcup-* > SHA256SUMS
 gpg --detach-sign -u "${SIGNER}" SHA256SUMS
 
-gh release upload "$RELEASE" "ghcup-${RELEASE}-src.tar.gz" "x86_64-portbld-freebsd-ghcup-${RELEASE}" SHA256SUMS SHA256SUMS.sig
+gh release upload "$RELEASE" "ghcup-${TAG}-src.tar.gz" "x86_64-portbld-freebsd-ghcup-${TAG}" SHA256SUMS SHA256SUMS.sig


### PR DESCRIPTION
- [x] update version in `ghcup.cabal`
- [x] update `ghcupURL` in `GHCup.Version` if need be
- [x] add ChangeLog entry
- [x] update data/metadata submodule
- [x] create tag and let CI create draft release
- [x] upload release artifacts to downloads.haskell.org
- [x] update YAML files in ghcup-metadata with new GHCup binaries
- [ ] update ghcup-hs submodule in ghcup-metadata
- [x] upload yamls to webhost.haskell.org/ghcup/data/ as well
- [x] update `ghver` in `scripts/bootstrap/bootstrap-haskell`
- [x] upload `scripts/bootstrap/bootstrap-haskell`
- [x] update top-level symlinks in downloads.haskell.org/~ghcup
- [x] publish release on github
- [x] upload to hackage
