### PR TITLE
fix: project build error when build with cabal build --allow-newer and GHC 9.2.5

### DIFF
--- a/lib/GHCup/Prelude.hs
+++ b/lib/GHCup/Prelude.hs
@@ -77,8 +77,14 @@ runBothE' a1 a2 = do
       (_       , VLeft e ) -> throwSomeE e
       (VRight _, VRight _) -> pure ()
 
+-- "throwSomeE" function has been upstreamed in haskus-utils-variant-3.3
+-- So, only conditionally include this shim if
+-- haskus-utils-variant version is < 3.3
 
+#if MIN_VERSION_haskus_utils_variant(3,3,0)
+#else
 -- | Throw some exception
 throwSomeE :: forall es' es a m. (Monad m, LiftVariant es' es) => V es' -> Excepts es m a
 {-# INLINABLE throwSomeE #-}
 throwSomeE = Excepts . pure . VLeft . liftVariant
+#endif


### PR DESCRIPTION
Fixes #806 

* New `haskus-utils-variant` version `3.3` now includes the function `throwSomeE`, which was now causing a compile error, since we have a function of the same name in our code and we don't import `Haskus.Utils.Variant.Excepts` as a qualified import.

* The function imported from the package and our own internal version of the function clashed.

* Solution was to conditionally include our shim when haskus-utils-variant version < 3.3, so it should work with most scenarios.

* We can remove the conditional include completely if we raise the min-bounds of version of `haskus-utils-variant` package in our cabal-file to 3.3.x or higher in the future.