### PR TITLE
Use correct environment variable for `STACK_ROOT` in bootstrap script

### DIFF
--- a/scripts/bootstrap/bootstrap-haskell
+++ b/scripts/bootstrap/bootstrap-haskell
@@ -851,8 +851,8 @@ case $ask_stack_answer in
 		;;
 	2)
         (_eghcup --cache install stack) || die "Stack installation failed"
-        edo mkdir -p "${STACK_ROOOT:-$HOME/.stack}"/hooks
-        hook_exe="${STACK_ROOOT:-$HOME/.stack}"/hooks/ghc-install.sh
+        edo mkdir -p "${STACK_ROOT:-$HOME/.stack}"/hooks
+        hook_exe="${STACK_ROOT:-$HOME/.stack}"/hooks/ghc-install.sh
         hook_url="https://www.haskell.org/ghcup/sh/hooks/stack/ghc-install.sh"
 
         if [ -e "${hook_exe}" ] ; then


### PR DESCRIPTION
The environment variable used to set the root Stack directory was incorrectly defined as `STACK_ROOOT` (typo with an extra 'O'). 

This has been fixed and the correct `STACK_ROOT` variable is now used.

See: https://docs.haskellstack.org/en/stable/environment_variables/#stack_root