### PR TITLE
Allow cross-compilation with Hadrian

### DIFF
--- a/.github/scripts/cabal-cache.sh
+++ b/.github/scripts/cabal-cache.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+case "$(uname -s)" in
+	MSYS_*|MINGW*)
+		ext=".exe"
+		;;
+	*)
+		ext=""
+	   ;;
+esac
+
+if [ "${CABAL_CACHE_DISABLE}" = "yes" ] ; then
+	echo "cabal-cache disabled (CABAL_CACHE_DISABLE set)"
+elif [ "${CABAL_CACHE_NONFATAL}" = "yes" ] ; then
+	time "cabal-cache${ext}" "$@" || echo "cabal-cache failed (CABAL_CACHE_NONFATAL set)"
+else
+	time "cabal-cache${ext}" "$@"
+	exit $?
+fi
+

--- a/.github/scripts/cabal-cache.sh
+++ b/.github/scripts/cabal-cache.sh
@@ -9,12 +9,5 @@ case "$(uname -s)" in
 	   ;;
 esac
 
-if [ "${CABAL_CACHE_DISABLE}" = "yes" ] ; then
-	echo "cabal-cache disabled (CABAL_CACHE_DISABLE set)"
-elif [ "${CABAL_CACHE_NONFATAL}" = "yes" ] ; then
-	time "cabal-cache${ext}" "$@" || echo "cabal-cache failed (CABAL_CACHE_NONFATAL set)"
-else
-	time "cabal-cache${ext}" "$@"
-	exit $?
-fi
+echo "cabal-cache disabled (CABAL_CACHE_DISABLE set)"
 

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -15,7 +15,7 @@ sync_from() {
 		cabal_store_path="$(dirname "$(cabal help user-config | tail -n 1 | xargs)")/store"
 	fi
 
-	cabal-cache sync-from-archive \
+	cabal-cache.sh sync-from-archive \
 		--host-name-override=${S3_HOST} \
 		--host-port-override=443 \
 		--host-ssl-override=True \
@@ -29,7 +29,7 @@ sync_to() {
 		cabal_store_path="$(dirname "$(cabal help user-config | tail -n 1 | xargs)")/store"
 	fi
 
-	cabal-cache sync-to-archive \
+	cabal-cache.sh sync-to-archive \
 		--host-name-override=${S3_HOST} \
 		--host-port-override=443 \
 		--host-ssl-override=True \
@@ -115,6 +115,10 @@ download_cabal_cache() {
 		mv "cabal-cache${exe}" "${dest}${exe}"
 		chmod +x "${dest}${exe}"
 	fi
+
+	# install shell wrapper
+	cp "${CI_PROJECT_DIR}"/.github/scripts/cabal-cache.sh "$HOME"/.local/bin/
+	chmod +x "$HOME"/.local/bin/cabal-cache.sh
     )
 }
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,10 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+env:
+  CABAL_CACHE_DISABLE: ${{ vars.CABAL_CACHE_DISABLE }}
+  CABAL_CACHE_NONFATAL: yes
+
 jobs:
   build-linux:
     name: Build linux binary

--- a/app/ghcup/BrickMain.hs
+++ b/app/ghcup/BrickMain.hs
@@ -156,10 +156,10 @@ ui dimAttrs BrickState{ appSettings = as@BrickSettings{}, ..}
       <+> padLeft (Pad 1) (minHSize 25 $ str "Tags")
       <+> padLeft (Pad 5) (str "Notes")
   renderList' bis@BrickInternalState{..} =
-    let getMinLength = length . intercalate "," . fmap tagToString
-        minLength = V.maximum $ V.map (getMinLength . lTag) clr
-    in withDefAttr listAttr . drawListElements (renderItem minLength) True $ bis
-  renderItem minTagSize _ b listResult@ListResult{lTag = lTag', ..} =
+    let minTagSize = V.maximum $ V.map (length . intercalate "," . fmap tagToString . lTag) clr
+        minVerSize = V.maximum $ V.map (\ListResult{..} -> T.length $ tVerToText (GHCTargetVersion lCross lVer)) clr
+    in withDefAttr listAttr . drawListElements (renderItem minTagSize minVerSize) True $ bis
+  renderItem minTagSize minVerSize _ b listResult@ListResult{lTag = lTag', ..} =
     let marks = if
           | lSet       -> (withAttr (attrName "set") $ str "✔✔")
           | lInstalled -> (withAttr (attrName "installed") $ str "✓ ")
@@ -184,7 +184,7 @@ ui dimAttrs BrickState{ appSettings = as@BrickSettings{}, ..}
                ( minHSize 6
                  (printTool lTool)
                )
-          <+> minHSize 15 (str ver)
+          <+> minHSize minVerSize (str ver)
           <+> (let l = catMaybes . fmap printTag $ sort lTag'
                in  padLeft (Pad 1) $ minHSize minTagSize $ if null l
                      then emptyWidget

--- a/app/ghcup/BrickMain.hs
+++ b/app/ghcup/BrickMain.hs
@@ -472,19 +472,19 @@ install' _ (_, ListResult {..}) = do
       dirs <- lift getDirs
       case lTool of
         GHC   -> do
-          let vi = getVersionInfo lVer GHC dls
-          liftE $ installGHCBin lVer GHCupInternal False [] $> (vi, dirs, ce)
+          let vi = getVersionInfo (GHCTargetVersion lCross lVer) GHC dls
+          liftE $ installGHCBin (GHCTargetVersion lCross lVer) GHCupInternal False [] $> (vi, dirs, ce)
         Cabal -> do
-          let vi = getVersionInfo lVer Cabal dls
+          let vi = getVersionInfo (GHCTargetVersion lCross lVer) Cabal dls
           liftE $ installCabalBin lVer GHCupInternal False $> (vi, dirs, ce)
         GHCup -> do
           let vi = snd <$> getLatest dls GHCup
           liftE $ upgradeGHCup Nothing False False $> (vi, dirs, ce)
         HLS   -> do
-          let vi = getVersionInfo lVer HLS dls
+          let vi = getVersionInfo (GHCTargetVersion lCross lVer) HLS dls
           liftE $ installHLSBin lVer GHCupInternal False $> (vi, dirs, ce)
         Stack -> do
-          let vi = getVersionInfo lVer Stack dls
+          let vi = getVersionInfo (GHCTargetVersion lCross lVer) Stack dls
           liftE $ installStackBin lVer GHCupInternal False $> (vi, dirs, ce)
     )
     >>= \case
@@ -565,7 +565,7 @@ del' _ (_, ListResult {..}) = do
   let run = runE @'[NotInstalled, UninstallFailed]
 
   run (do
-      let vi = getVersionInfo lVer lTool dls
+      let vi = getVersionInfo (GHCTargetVersion lCross lVer) lTool dls
       case lTool of
         GHC   -> liftE $ rmGHCVer (GHCTargetVersion lCross lVer) $> vi
         Cabal -> liftE $ rmCabalVer lVer $> vi

--- a/app/ghcup/GHCup/OptParse/Compile.hs
+++ b/app/ghcup/GHCup/OptParse/Compile.hs
@@ -66,7 +66,7 @@ data CompileCommand = CompileGHC GHCCompileOptions
 
 
 data GHCCompileOptions = GHCCompileOptions
-  { targetGhc    :: GHC.GHCVer Version
+  { targetGhc    :: GHC.GHCVer
   , bootstrapGhc :: Either Version FilePath
   , jobs         :: Maybe Int
   , buildConfig  :: Maybe FilePath
@@ -568,10 +568,8 @@ compile compileCommand settings Dirs{..} runAppState runLogger = do
               liftIO $ threadDelay 5000000 -- for compilation, give the user a sec to intervene
           _ -> pure ()
         targetVer <- liftE $ compileGHC
-                    ((\case
-                        GHC.SourceDist v -> GHC.SourceDist $ GHCTargetVersion crossTarget v
-                        GHC.GitDist g -> GHC.GitDist g
-                        GHC.RemoteDist r -> GHC.RemoteDist r) targetGhc)
+                    targetGhc
+                    crossTarget
                     ovewrwiteVer
                     bootstrapGhc
                     jobs

--- a/app/ghcup/GHCup/OptParse/Compile.hs
+++ b/app/ghcup/GHCup/OptParse/Compile.hs
@@ -77,7 +77,6 @@ data GHCCompileOptions = GHCCompileOptions
   , ovewrwiteVer :: Maybe Version
   , buildFlavour :: Maybe String
   , hadrian      :: Bool
-  , bignum       :: Maybe String
   , isolateDir   :: Maybe FilePath
   }
 
@@ -271,13 +270,6 @@ ghcCompileOpts =
           )
     <*> switch
           (long "hadrian" <> help "Use the hadrian build system instead of make (only git versions seem to be properly supported atm)"
-          )
-    <*> optional
-          (option
-            str
-            (long "bignum" <> metavar "INTEGER_BACKEND" <> help
-              "Set the integer backend. This value differs between make ('integer-gmp' and 'integer-simple') and hadrian ('gmp' and 'native')"
-            )
           )
     <*> optional
           (option
@@ -585,7 +577,6 @@ compile compileCommand settings Dirs{..} runAppState runLogger = do
                     patches
                     addConfArgs
                     buildFlavour
-                    bignum
                     hadrian
                     (maybe GHCupInternal IsolateDir isolateDir)
         GHCupInfo { _ghcupDownloads = dls } <- lift getGHCupInfo

--- a/app/ghcup/GHCup/OptParse/Compile.hs
+++ b/app/ghcup/GHCup/OptParse/Compile.hs
@@ -555,9 +555,6 @@ compile compileCommand settings Dirs{..} runAppState runLogger = do
               VLeft e -> do
                 runLogger $ logError $ T.pack $ prettyHFError e
                 pure $ ExitFailure 9
-    (CompileGHC GHCCompileOptions { hadrian = True, crossTarget = Just _ }) -> do
-      runLogger $ logError "Hadrian cross compile support is not yet implemented!"
-      pure $ ExitFailure 9
     (CompileGHC GHCCompileOptions {..}) ->
       runCompileGHC runAppState (do
         case targetGhc of

--- a/app/ghcup/GHCup/OptParse/Install.hs
+++ b/app/ghcup/GHCup/OptParse/Install.hs
@@ -324,7 +324,7 @@ install installCommand settings getAppState' runLogger = case installCommand of
        Nothing -> runInstGHC s' $ do
          (v, vi) <- liftE $ fromVersion instVer GHC
          liftE $ runBothE' (installGHCBin
-                     (_tvVersion v)
+                     v
                      (maybe GHCupInternal IsolateDir isolateDir)
                      forceInstall
                      addConfArgs
@@ -336,7 +336,7 @@ install installCommand settings getAppState' runLogger = case installCommand of
            (v, vi) <- liftE $ fromVersion instVer GHC
            liftE $ runBothE' (installGHCBindist
                        (DownloadInfo uri (Just $ RegexDir "ghc-.*") "" Nothing Nothing)
-                       (_tvVersion v)
+                       v
                        (maybe GHCupInternal IsolateDir isolateDir)
                        forceInstall
                        addConfArgs

--- a/app/ghcup/GHCup/OptParse/Prefetch.hs
+++ b/app/ghcup/GHCup/OptParse/Prefetch.hs
@@ -195,7 +195,7 @@ prefetch prefetchCommand runAppState runLogger =
           forM_ pfCacheDir (liftIO . createDirRecursive')
           (v, _) <- liftE $ fromVersion mt GHC
           if pfGHCSrc
-          then liftE $ fetchGHCSrc (_tvVersion v) pfCacheDir
+          then liftE $ fetchGHCSrc v pfCacheDir
           else liftE $ fetchToolBindist (_tvVersion v) GHC pfCacheDir
       PrefetchCabal PrefetchOptions {pfCacheDir} mt   -> do
         forM_ pfCacheDir (liftIO . createDirRecursive')

--- a/app/ghcup/GHCup/OptParse/Rm.hs
+++ b/app/ghcup/GHCup/OptParse/Rm.hs
@@ -170,7 +170,7 @@ rm rmCommand runAppState runLogger = case rmCommand of
         liftE $
           rmGHCVer ghcVer
         GHCupInfo { _ghcupDownloads = dls } <- lift getGHCupInfo
-        pure (getVersionInfo (_tvVersion ghcVer) GHC dls)
+        pure (getVersionInfo ghcVer GHC dls)
       )
       >>= \case
             VRight vi -> do
@@ -186,7 +186,7 @@ rm rmCommand runAppState runLogger = case rmCommand of
         liftE $
           rmCabalVer tv
         GHCupInfo { _ghcupDownloads = dls } <- lift getGHCupInfo
-        pure (getVersionInfo tv Cabal dls)
+        pure (getVersionInfo (mkTVer tv) Cabal dls)
       )
       >>= \case
             VRight vi -> do
@@ -201,7 +201,7 @@ rm rmCommand runAppState runLogger = case rmCommand of
         liftE $
           rmHLSVer tv
         GHCupInfo { _ghcupDownloads = dls } <- lift getGHCupInfo
-        pure (getVersionInfo tv HLS dls)
+        pure (getVersionInfo (mkTVer tv) HLS dls)
       )
       >>= \case
             VRight vi -> do
@@ -216,7 +216,7 @@ rm rmCommand runAppState runLogger = case rmCommand of
         liftE $
           rmStackVer tv
         GHCupInfo { _ghcupDownloads = dls } <- lift getGHCupInfo
-        pure (getVersionInfo tv Stack dls)
+        pure (getVersionInfo (mkTVer tv) Stack dls)
       )
       >>= \case
             VRight vi -> do

--- a/app/ghcup/GHCup/OptParse/Run.hs
+++ b/app/ghcup/GHCup/OptParse/Run.hs
@@ -360,7 +360,7 @@ run RunOptions{..} runAppState leanAppstate runLogger = do
            Just v -> do
              isInstalled <- lift $ checkIfToolInstalled' GHC v
              unless isInstalled $ when (runInstTool' && isNothing (_tvTarget v)) $ void $ liftE $ installGHCBin
-               (_tvVersion v)
+               v
                GHCupInternal
                False
                []

--- a/app/ghcup/GHCup/OptParse/Test.hs
+++ b/app/ghcup/GHCup/OptParse/Test.hs
@@ -169,12 +169,12 @@ test testCommand settings getAppState' runLogger = case testCommand of
     (case testBindist of
        Nothing -> runTestGHC s' $ do
          (v, vi) <- liftE $ fromVersion testVer GHC
-         liftE $ testGHCVer (_tvVersion v) addMakeArgs
+         liftE $ testGHCVer v addMakeArgs
          pure vi
        Just uri -> do
          runTestGHC s'{ settings = settings {noVerify = True}} $ do
            (v, vi) <- liftE $ fromVersion testVer GHC
-           liftE $ testGHCBindist (DownloadInfo uri (Just $ RegexDir ".*/.*") "" Nothing Nothing) (_tvVersion v) addMakeArgs
+           liftE $ testGHCBindist (DownloadInfo uri (Just $ RegexDir ".*/.*") "" Nothing Nothing) v addMakeArgs
            pure vi
       )
         >>= \case

--- a/app/ghcup/Main.hs
+++ b/app/ghcup/Main.hs
@@ -249,7 +249,7 @@ Report bugs at <https://github.com/haskell/ghcup-hs/issues>|]
                                case t of
                                  GHCup -> runLogger $
                                             logWarn ("New GHCup version available: "
-                                              <> prettyVer l
+                                              <> tVerToText l
                                               <> ". To upgrade, run 'ghcup upgrade'")
                                  _ -> runLogger $
                                         logWarn ("New "
@@ -258,7 +258,7 @@ Report bugs at <https://github.com/haskell/ghcup-hs/issues>|]
                                           <> "If you want to install this latest version, run 'ghcup install "
                                           <> T.pack (prettyShow t)
                                           <> " "
-                                          <> prettyVer l
+                                          <> tVerToText l
                                           <> "'")
                          Just _ -> pure ()
 
@@ -332,7 +332,7 @@ Report bugs at <https://github.com/haskell/ghcup-hs/issues>|]
                        , MonadCatch m
                        )
                     => Command
-                    -> (Tool, Version)
+                    -> (Tool, GHCTargetVersion)
                     -> Excepts
                          '[ TagNotFound
                           , DayNotFound
@@ -368,7 +368,7 @@ Report bugs at <https://github.com/haskell/ghcup-hs/issues>|]
           )
        => Tool
        -> Maybe ToolVersion
-       -> Version
+       -> GHCTargetVersion
        -> Excepts
             '[ TagNotFound
              , DayNotFound
@@ -377,4 +377,4 @@ Report bugs at <https://github.com/haskell/ghcup-hs/issues>|]
              ] m Bool
   cmp' tool instVer ver = do
     (v, _) <- liftE $ fromVersion instVer tool
-    pure (v == mkTVer ver)
+    pure (v == ver)

--- a/lib/GHCup.hs
+++ b/lib/GHCup.hs
@@ -303,7 +303,7 @@ upgradeGHCup mtarget force' fatal = do
   GHCupInfo { _ghcupDownloads = dls } <- lift getGHCupInfo
 
   lift $ logInfo "Upgrading GHCup..."
-  let latestVer = fst (fromJust (getLatest dls GHCup))
+  let latestVer = _tvVersion $ fst (fromJust (getLatest dls GHCup))
   (Just ghcupPVPVer) <- pure $ pvpToVersion ghcUpVer ""
   when (not force' && (latestVer <= ghcupPVPVer)) $ throwE NoUpdate
   dli   <- liftE $ getDownloadInfo GHCup latestVer
@@ -492,7 +492,7 @@ rmOldGHC :: ( MonadReader env m
          => Excepts '[NotInstalled, UninstallFailed] m ()
 rmOldGHC = do
   GHCupInfo { _ghcupDownloads = dls } <- lift getGHCupInfo
-  let oldGHCs = mkTVer <$> toListOf (ix GHC % getTagged Old % to fst) dls
+  let oldGHCs = toListOf (ix GHC % getTagged Old % to fst) dls
   ghcs <- lift $ fmap rights getInstalledGHCs
   forM_ ghcs $ \ghc -> when (ghc `elem` oldGHCs) $ rmGHCVer ghc
 

--- a/lib/GHCup/Download.hs
+++ b/lib/GHCup/Download.hs
@@ -271,7 +271,6 @@ getBase uri = do
 
       pure f
 
-
 getDownloadInfo :: ( MonadReader env m
                    , HasPlatformReq env
                    , HasGHCupInfo env
@@ -283,7 +282,20 @@ getDownloadInfo :: ( MonadReader env m
                      '[NoDownload]
                      m
                      DownloadInfo
-getDownloadInfo t v = do
+getDownloadInfo t v = getDownloadInfo' t (mkTVer v)
+
+getDownloadInfo' :: ( MonadReader env m
+                    , HasPlatformReq env
+                    , HasGHCupInfo env
+                    )
+                 => Tool
+                 -> GHCTargetVersion
+                 -- ^ tool version
+                 -> Excepts
+                      '[NoDownload]
+                      m
+                      DownloadInfo
+getDownloadInfo' t v = do
   (PlatformRequest a p mv) <- lift getPlatformReq
   GHCupInfo { _ghcupDownloads = dls } <- lift getGHCupInfo
 

--- a/lib/GHCup/GHC.hs
+++ b/lib/GHCup/GHC.hs
@@ -1015,8 +1015,6 @@ compileGHC targetGhc ov bstrap jobs mbuildConfig patches aargs buildFlavour hadr
                              m
                              (Maybe FilePath)  -- ^ output path of bindist, None for cross
   compileHadrianBindist tver workdir ghcdir = do
-    lEM $ execWithGhcEnv "python3" ["./boot"] (Just workdir) "ghc-bootstrap"
-
     liftE $ configureBindist tver workdir ghcdir
 
     lift $ logInfo "Building (this may take a while)..."

--- a/lib/GHCup/GHC.hs
+++ b/lib/GHCup/GHC.hs
@@ -764,7 +764,6 @@ compileGHC :: ( MonadMask m
            -> Maybe (Either FilePath [URI])  -- ^ patches
            -> [Text]                   -- ^ additional args to ./configure
            -> Maybe String             -- ^ build flavour
-           -> Maybe String             -- ^ bignum
            -> Bool
            -> InstallDir
            -> Excepts
@@ -794,7 +793,7 @@ compileGHC :: ( MonadMask m
                  ]
                 m
                 GHCTargetVersion
-compileGHC targetGhc crossTarget ov bstrap jobs mbuildConfig patches aargs buildFlavour bignum hadrian installDir
+compileGHC targetGhc crossTarget ov bstrap jobs mbuildConfig patches aargs buildFlavour hadrian installDir
   = do
     PlatformRequest { .. } <- lift getPlatformReq
     GHCupInfo { _ghcupDownloads = dls } <- lift getGHCupInfo
@@ -1024,7 +1023,6 @@ compileGHC targetGhc crossTarget ov bstrap jobs mbuildConfig patches aargs build
     lEM $ execWithGhcEnv hadrian_build
                           ( maybe [] (\j  -> ["-j" <> show j]         ) jobs
                          ++ maybe [] (\bf -> ["--flavour=" <> bf]) buildFlavour
-                         ++ maybe [] (\bn -> ["--bignum=" <> bn]) bignum
                          ++ ["binary-dist"]
                           )
                           (Just workdir) "ghc-make"
@@ -1083,7 +1081,7 @@ compileGHC targetGhc crossTarget ov bstrap jobs mbuildConfig patches aargs build
         (FileDoesNotExistError bc)
         (liftIO $ copyFile bc (build_mk workdir) False)
       Nothing ->
-        liftIO $ T.writeFile (build_mk workdir) (addBigNumToConf $ addBuildFlavourToConf defaultConf)
+        liftIO $ T.writeFile (build_mk workdir) (addBuildFlavourToConf defaultConf)
 
     liftE $ checkBuildConfig (build_mk workdir)
 
@@ -1179,10 +1177,6 @@ compileGHC targetGhc crossTarget ov bstrap jobs mbuildConfig patches aargs build
 
   addBuildFlavourToConf bc = case buildFlavour of
     Just bf -> "BuildFlavour = " <> T.pack bf <> "\n" <> bc
-    Nothing -> bc
-
-  addBigNumToConf bc = case bignum of
-    Just bn -> bc <> "\nINTEGER_LIBRARY = " <> T.pack bn
     Nothing -> bc
 
   isCross :: GHCTargetVersion -> Bool

--- a/lib/GHCup/HLS.hs
+++ b/lib/GHCup/HLS.hs
@@ -369,7 +369,7 @@ compileHLS targetHLS ghcs jobs ov installDir cabalProject cabalProjectLocal upda
 
       -- download source tarball
       dlInfo <-
-        preview (ix HLS % ix tver % viSourceDL % _Just) dls
+        preview (ix HLS % ix (mkTVer tver) % viSourceDL % _Just) dls
           ?? NoDownload
       dl <- liftE $ downloadCached dlInfo Nothing
 

--- a/lib/GHCup/List.hs
+++ b/lib/GHCup/List.hs
@@ -164,17 +164,17 @@ listVersions lt' criteria hideOld showNightly days = do
   strayGHCs avTools = do
     ghcs <- getInstalledGHCs
     fmap catMaybes $ forM ghcs $ \case
-      Right tver@GHCTargetVersion{ _tvTarget = Nothing, .. } -> do
+      Right tver@GHCTargetVersion{ .. } -> do
         case Map.lookup tver avTools of
           Just _  -> pure Nothing
           Nothing -> do
-            lSet    <- fmap (maybe False (\(GHCTargetVersion _ v ) -> v == _tvVersion)) $ ghcSet Nothing
+            lSet    <- fmap (maybe False (\(GHCTargetVersion _ v ) -> v == _tvVersion)) $ ghcSet _tvTarget
             fromSrc <- ghcSrcInstalled tver
             hlsPowered <- fmap (elem _tvVersion) hlsGHCVersions
             pure $ Just $ ListResult
               { lTool      = GHC
               , lVer       = _tvVersion
-              , lCross     = Nothing
+              , lCross     = _tvTarget
               , lTag       = []
               , lInstalled = True
               , lStray     = isNothing (Map.lookup tver avTools)
@@ -182,21 +182,6 @@ listVersions lt' criteria hideOld showNightly days = do
               , lReleaseDay = Nothing
               , ..
               }
-      Right tver@GHCTargetVersion{ .. } -> do
-        lSet    <- fmap (maybe False (\(GHCTargetVersion _ v ) -> v == _tvVersion)) $ ghcSet _tvTarget
-        fromSrc <- ghcSrcInstalled tver
-        hlsPowered <- fmap (elem _tvVersion) hlsGHCVersions
-        pure $ Just $ ListResult
-          { lTool      = GHC
-          , lVer       = _tvVersion
-          , lCross     = _tvTarget
-          , lTag       = []
-          , lInstalled = True
-          , lStray     = isNothing (Map.lookup tver avTools)
-          , lNoBindist = False
-          , lReleaseDay = Nothing
-          , ..
-          }
       Left e -> do
         logWarn
           $ "Could not parse version of stray directory" <> T.pack e

--- a/lib/GHCup/List.hs
+++ b/lib/GHCup/List.hs
@@ -86,7 +86,7 @@ data ListResult = ListResult
 
 
 -- | Extract all available tool versions and their tags.
-availableToolVersions :: GHCupDownloads -> Tool -> Map.Map Version VersionInfo
+availableToolVersions :: GHCupDownloads -> Tool -> Map.Map GHCTargetVersion VersionInfo
 availableToolVersions av tool = view
   (at tool % non Map.empty)
   av
@@ -134,13 +134,13 @@ listVersions lt' criteria hideOld showNightly days = do
             slr <- strayGHCs avTools
             pure (sort (slr ++ lr))
           Cabal -> do
-            slr <- strayCabals avTools cSet cabals
+            slr <- strayCabals (Map.mapKeys _tvVersion avTools) cSet cabals
             pure (sort (slr ++ lr))
           HLS -> do
-            slr <- strayHLS avTools hlsSet' hlses
+            slr <- strayHLS (Map.mapKeys _tvVersion avTools) hlsSet' hlses
             pure (sort (slr ++ lr))
           Stack -> do
-            slr <- strayStacks avTools sSet stacks
+            slr <- strayStacks (Map.mapKeys _tvVersion avTools) sSet stacks
             pure (sort (slr ++ lr))
           GHCup -> do
             let cg = maybeToList $ currentGHCup avTools
@@ -159,13 +159,13 @@ listVersions lt' criteria hideOld showNightly days = do
                , HasLog env
                , MonadIO m
                )
-            => Map.Map Version VersionInfo
+            => Map.Map GHCTargetVersion VersionInfo
             -> m [ListResult]
   strayGHCs avTools = do
     ghcs <- getInstalledGHCs
     fmap catMaybes $ forM ghcs $ \case
       Right tver@GHCTargetVersion{ _tvTarget = Nothing, .. } -> do
-        case Map.lookup _tvVersion avTools of
+        case Map.lookup tver avTools of
           Just _  -> pure Nothing
           Nothing -> do
             lSet    <- fmap (maybe False (\(GHCTargetVersion _ v ) -> v == _tvVersion)) $ ghcSet Nothing
@@ -177,7 +177,7 @@ listVersions lt' criteria hideOld showNightly days = do
               , lCross     = Nothing
               , lTag       = []
               , lInstalled = True
-              , lStray     = isNothing (Map.lookup _tvVersion avTools)
+              , lStray     = isNothing (Map.lookup tver avTools)
               , lNoBindist = False
               , lReleaseDay = Nothing
               , ..
@@ -192,7 +192,7 @@ listVersions lt' criteria hideOld showNightly days = do
           , lCross     = _tvTarget
           , lTag       = []
           , lInstalled = True
-          , lStray     = True -- NOTE: cross currently cannot be installed via bindist
+          , lStray     = isNothing (Map.lookup tver avTools)
           , lNoBindist = False
           , lReleaseDay = Nothing
           , ..
@@ -309,15 +309,15 @@ listVersions lt' criteria hideOld showNightly days = do
           $ "Could not parse version of stray directory" <> T.pack e
         pure Nothing
 
-  currentGHCup :: Map.Map Version VersionInfo -> Maybe ListResult
+  currentGHCup :: Map.Map GHCTargetVersion VersionInfo -> Maybe ListResult
   currentGHCup av =
-    let currentVer = fromJust $ pvpToVersion ghcUpVer ""
+    let currentVer = mkTVer $ fromJust $ pvpToVersion ghcUpVer ""
         listVer    = Map.lookup currentVer av
         latestVer  = fst <$> headOf (getTagged Latest) av
         recommendedVer = fst <$> headOf (getTagged Latest) av
         isOld  = maybe True (> currentVer) latestVer && maybe True (> currentVer) recommendedVer
     in if | Map.member currentVer av -> Nothing
-          | otherwise -> Just $ ListResult { lVer    = currentVer
+          | otherwise -> Just $ ListResult { lVer    = _tvVersion currentVer
                                            , lTag    = maybe (if isOld then [Old] else []) _viTags listVer
                                            , lCross  = Nothing
                                            , lTool   = GHCup
@@ -346,18 +346,18 @@ listVersions lt' criteria hideOld showNightly days = do
                -> [Either FilePath Version]
                -> Maybe Version
                -> [Either FilePath Version]
-               -> (Version, VersionInfo)
+               -> (GHCTargetVersion, VersionInfo)
                -> m ListResult
-  toListResult t cSet cabals hlsSet' hlses stackSet' stacks (v, VersionInfo{..}) = do
+  toListResult t cSet cabals hlsSet' hlses stackSet' stacks (tver, VersionInfo{..}) = do
+    let v = _tvVersion tver
     case t of
       GHC -> do
-        lNoBindist <- fmap (isLeft . veitherToEither) $ runE @'[NoDownload] $ getDownloadInfo GHC v
-        let tver = mkTVer v
-        lSet       <- fmap (maybe False (\(GHCTargetVersion _ v') -> v' == v)) $ ghcSet Nothing
+        lNoBindist <- fmap (isLeft . veitherToEither) $ runE @'[NoDownload] $ getDownloadInfo' GHC tver
+        lSet       <- fmap (== Just tver) $ ghcSet (_tvTarget tver)
         lInstalled <- ghcInstalled tver
         fromSrc    <- ghcSrcInstalled tver
-        hlsPowered <- fmap (elem v) hlsGHCVersions
-        pure ListResult { lVer = v, lCross = Nothing , lTag = _viTags, lTool = t, lStray = False, lReleaseDay = _viReleaseDay, .. }
+        hlsPowered <- fmap (elem tver) (fmap mkTVer <$> hlsGHCVersions)
+        pure ListResult { lVer = _tvVersion tver , lCross = _tvTarget tver , lTag = _viTags, lTool = t, lStray = False, lReleaseDay = _viReleaseDay, .. }
       Cabal -> do
         lNoBindist <- fmap (isLeft . veitherToEither) $ runE @'[NoDownload] $ getDownloadInfo Cabal v
         let lSet = cSet == Just v

--- a/lib/GHCup/Types.hs
+++ b/lib/GHCup/Types.hs
@@ -104,7 +104,7 @@ instance NFData Requirements
 -- | Description of all binary and source downloads. This is a tree
 -- of nested maps.
 type GHCupDownloads = Map Tool ToolVersionSpec
-type ToolVersionSpec = Map Version VersionInfo
+type ToolVersionSpec = Map GHCTargetVersion VersionInfo
 type ArchitectureSpec = Map Architecture PlatformSpec
 type PlatformSpec = Map Platform PlatformVersionSpec
 type PlatformVersionSpec = Map (Maybe VersionRange) DownloadInfo
@@ -593,7 +593,9 @@ data GHCTargetVersion = GHCTargetVersion
   { _tvTarget  :: Maybe Text
   , _tvVersion :: Version
   }
-  deriving (Ord, Eq, Show)
+  deriving (Ord, Eq, Show, GHC.Generic)
+
+instance NFData GHCTargetVersion
 
 data GitBranch = GitBranch
   { ref  :: String

--- a/lib/GHCup/Types/JSON.hs
+++ b/lib/GHCup/Types/JSON.hs
@@ -95,13 +95,29 @@ instance FromJSON URI where
       Right x -> pure x
       Left  e -> fail . show $ e
 
+instance ToJSON GHCTargetVersion where
+  toJSON = toJSON . tVerToText
+
+instance FromJSON GHCTargetVersion where
+  parseJSON = withText "GHCTargetVersion" $ \t -> case MP.parse ghcTargetVerP "" t of
+    Right x -> pure x
+    Left  e -> fail $ "Failure in GHCTargetVersion (FromJSON)" <> show e
+
+instance ToJSONKey GHCTargetVersion where
+  toJSONKey = toJSONKeyText $ \x -> tVerToText x
+
+instance FromJSONKey GHCTargetVersion where
+  fromJSONKey = FromJSONKeyTextParser $ \t -> case MP.parse ghcTargetVerP "" t of
+    Right x -> pure x
+    Left  e -> fail $ "Failure in GHCTargetVersion (FromJSONKey)" <> show e
+
 instance ToJSON Versioning where
   toJSON = toJSON . prettyV
 
 instance FromJSON Versioning where
   parseJSON = withText "Versioning" $ \t -> case versioning t of
     Right x -> pure x
-    Left  e -> fail $ "Failure in Version (FromJSON)" <> show e
+    Left  e -> fail $ "Failure in GHCTargetVersion (FromJSON)" <> show e
 
 instance ToJSONKey Versioning where
   toJSONKey = toJSONKeyText $ \x -> prettyV x

--- a/test/GHCup/ArbitraryTypes.hs
+++ b/test/GHCup/ArbitraryTypes.hs
@@ -183,6 +183,10 @@ instance Arbitrary GHCupInfo where
   arbitrary = genericArbitrary
   shrink    = genericShrink
 
+instance Arbitrary GHCTargetVersion where
+  arbitrary = GHCTargetVersion Nothing <$> arbitrary
+  shrink    = genericShrink
+
 
 -- our maps are nested... the default size easily blows up most ppls ram
 


### PR DESCRIPTION
Try to fix cross-compilation with Hadrian for the JS backend (cf #838).

Currently failing with:

```
emconfigure /home/hsyl20/projects/ghcup-hs/dist-newstyle/build/x86_64-linux/ghc-9.4.5/ghcup-0.1.19.4/x/ghcup/build/ghcup/ghcup compile ghc --version=9.6.2 --bootstrap-ghc=9.4.3 --cross-target=javascript-unknown-ghcjs -j8 --hadrian --flavour=default+native_bignum -v --keep errors

...

[ Info  ] Merging file tree from "/home/hsyl20/.ghcup/tmp/ghcup-d9469921e6dd5041/home/hsyl20/.ghcup/ghc/javascript-unknown-ghcjs-9.6.2" to "/home/hsyl20/.ghcup/ghc/javascript-unknown-ghcjs-9.6.2"
[ Error ] [GHCup-00080] Failed to merge file tree from /home/hsyl20/.ghcup/tmp/ghcup-d9469921e6dd5041/home/hsyl20/.ghcup/ghc/javascript-unknown-ghcjs-9.6.2 to /home/hsyl20/.ghcup/ghc/javascript-unknown-ghcjs-9.6.2
[ ...   ] exception was: user error (mergeFileTree: DB file /home/hsyl20/.ghcup/db/ghc/9.6.2 already exists!)
[ ...   ] ...you may need to delete /home/hsyl20/.ghcup/ghc/javascript-unknown-ghcjs-9.6.2 manually. Make sure it's gone.
emconfigure: error: '/home/hsyl20/projects/ghcup-hs/dist-newstyle/build/x86_64-linux/ghc-9.4.5/ghcup-0.1.19.4/x/ghcup/build/ghcup/ghcup compile ghc --version=9.6.2 --bootstrap-ghc=9.4.3 --cross-target=javascript-unknown-ghcjs -j8 --hadrian --flavour=default+native_bignum -v --keep errors' failed (returned 9)
```

Shouldn't dbs be distinguished for cross-compilers?