### PR TITLE
GHCup set command error improvement

### DIFF
--- a/app/ghcup/GHCup/OptParse/Common.hs
+++ b/app/ghcup/GHCup/OptParse/Common.hs
@@ -82,7 +82,7 @@ data SetToolVersion = SetGHCVersion GHCTargetVersion
                     | SetToolTag Tag
                     | SetToolDay Day
                     | SetRecommended
-                    | SetNext deriving Show
+                    | SetNext deriving (Eq, Show)
 
 prettyToolVer :: ToolVersion -> String
 prettyToolVer (GHCVersion v')  = T.unpack $ tVerToText v'

--- a/app/ghcup/GHCup/OptParse/Common.hs
+++ b/app/ghcup/GHCup/OptParse/Common.hs
@@ -82,7 +82,7 @@ data SetToolVersion = SetGHCVersion GHCTargetVersion
                     | SetToolTag Tag
                     | SetToolDay Day
                     | SetRecommended
-                    | SetNext
+                    | SetNext deriving Show
 
 prettyToolVer :: ToolVersion -> String
 prettyToolVer (GHCVersion v')  = T.unpack $ tVerToText v'

--- a/cabal.project
+++ b/cabal.project
@@ -23,3 +23,5 @@ package aeson
 package streamly
   flags: +use-unliftio
 
+package *
+  test-show-details: direct

--- a/ghcup.cabal
+++ b/ghcup.cabal
@@ -201,9 +201,8 @@ library
     cpp-options:   -DBRICK
     build-depends: vty ^>=5.37
 
-executable ghcup
-  main-is:            Main.hs
-  other-modules:
+library ghcup-optparse
+  exposed-modules:
     GHCup.OptParse
     GHCup.OptParse.ChangeLog
     GHCup.OptParse.Common
@@ -224,6 +223,81 @@ executable ghcup
     GHCup.OptParse.Upgrade
     GHCup.OptParse.Whereis
 
+  hs-source-dirs: app/ghcup
+  default-language: Haskell2010
+  default-extensions:
+    LambdaCase
+    MultiWayIf
+    NamedFieldPuns
+    PackageImports
+    RecordWildCards
+    ScopedTypeVariables
+    StrictData
+    TupleSections
+
+  ghc-options:
+    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    -fwarn-incomplete-record-updates
+
+  build-depends:
+    , aeson                  >=1.4
+    , aeson-pretty           ^>=0.8.8
+    , async                  ^>=2.2.3
+    , base                   >=4.12     && <5
+    , bytestring             >=0.10     && <0.12
+    , cabal-install-parsers  >=0.4.5
+    , cabal-plan             ^>=0.7.2
+    , containers             ^>=0.6
+    , deepseq                ^>=1.4
+    , directory              ^>=1.3.6.0
+    , filepath               ^>=1.4.2.1
+    , ghcup
+    , haskus-utils-types     ^>=1.5
+    , haskus-utils-variant   ^>=3.2.1
+    , libarchive             ^>=3.0.3.0
+    , megaparsec             >=8.0.0    && <9.3
+    , mtl                    ^>=2.2
+    , optparse-applicative   >=0.15.1.0 && <0.18
+    , pretty                 ^>=1.1.3.1
+    , pretty-terminal        ^>=0.1.0.0
+    , process                ^>=1.6.11.0
+    , resourcet              ^>=1.2.2
+    , safe                   ^>=0.3.18
+    , safe-exceptions        ^>=0.1
+    , tagsoup                ^>=0.14
+    , template-haskell       >=2.7      && <2.20
+    , temporary              ^>=1.3
+    , text                   ^>=2.0
+    , time                   ^>=1.9.3 || ^>=1.10 || ^>=1.11
+    , unordered-containers   ^>=0.2
+    , uri-bytestring         ^>=0.3.2.2
+    , utf8-string            ^>=1.0
+    , vector                 ^>=0.12
+    , versions               >=4.0.1    && <5.1
+    , yaml-streamly          ^>=0.12.0
+
+  if flag(internal-downloader)
+    cpp-options: -DINTERNAL_DOWNLOADER
+
+  if (flag(tui) && !os(windows))
+    cpp-options:   -DBRICK
+    other-modules: BrickMain
+    build-depends:
+      , brick         ^>=1.5
+      , transformers  ^>=0.5
+      , unix          ^>=2.7
+      , vty           ^>=5.37
+
+  if os(windows)
+    cpp-options: -DIS_WINDOWS
+
+  else
+    build-depends: unix ^>=2.7
+
+
+executable ghcup
+  main-is:            Main.hs
+
   hs-source-dirs:     app/ghcup
   default-language:   Haskell2010
   default-extensions:
@@ -241,6 +315,7 @@ executable ghcup
     -fwarn-incomplete-record-updates -threaded
 
   build-depends:
+    , ghcup-optparse
     , aeson                  >=1.4
     , aeson-pretty           ^>=0.8.8
     , async                  ^>=2.2.3
@@ -346,3 +421,11 @@ test-suite ghcup-test
 
   else
     build-depends: unix ^>=2.7
+
+test-suite ghcup-optparse-test
+  type: exitcode-stdio-1.0
+  hs-source-dirs: optparse-test
+  main-is: Main.hs
+  default-language: Haskell2010
+  ghc-options: -Wall
+  build-depends: base, ghcup, ghcup-optparse, tasty, tasty-hunit, optparse-applicative, versions, text

--- a/ghcup.cabal
+++ b/ghcup.cabal
@@ -53,6 +53,43 @@ flag no-exe
   default:     False
   manual:      True
 
+common app-common-depends
+  build-depends:
+    , aeson                  >=1.4
+    , aeson-pretty           ^>=0.8.8
+    , async                  ^>=2.2.3
+    , base                   >=4.12     && <5
+    , bytestring             >=0.10     && <0.12
+    , cabal-install-parsers  >=0.4.5
+    , cabal-plan             ^>=0.7.2
+    , containers             ^>=0.6
+    , deepseq                ^>=1.4
+    , directory              ^>=1.3.6.0
+    , filepath               ^>=1.4.2.1
+    , haskus-utils-types     ^>=1.5
+    , haskus-utils-variant   ^>=3.2.1
+    , libarchive             ^>=3.0.3.0
+    , megaparsec             >=8.0.0    && <9.3
+    , mtl                    ^>=2.2
+    , optparse-applicative   >=0.15.1.0 && <0.18
+    , pretty                 ^>=1.1.3.1
+    , pretty-terminal        ^>=0.1.0.0
+    , process                ^>=1.6.11.0
+    , resourcet              ^>=1.2.2
+    , safe                   ^>=0.3.18
+    , safe-exceptions        ^>=0.1
+    , tagsoup                ^>=0.14
+    , template-haskell       >=2.7      && <2.20
+    , temporary              ^>=1.3
+    , text                   ^>=2.0
+    , time                   ^>=1.9.3 || ^>=1.10 || ^>=1.11
+    , unordered-containers   ^>=0.2
+    , uri-bytestring         ^>=0.3.2.2
+    , utf8-string            ^>=1.0
+    , vector                 ^>=0.12
+    , versions               >=4.0.1    && <5.1
+    , yaml-streamly          ^>=0.12.0
+
 library
   exposed-modules:
     GHCup
@@ -202,6 +239,7 @@ library
     build-depends: vty ^>=5.37
 
 library ghcup-optparse
+  import: app-common-depends
   exposed-modules:
     GHCup.OptParse
     GHCup.OptParse.ChangeLog
@@ -239,42 +277,7 @@ library ghcup-optparse
     -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
     -fwarn-incomplete-record-updates
 
-  build-depends:
-    , aeson                  >=1.4
-    , aeson-pretty           ^>=0.8.8
-    , async                  ^>=2.2.3
-    , base                   >=4.12     && <5
-    , bytestring             >=0.10     && <0.12
-    , cabal-install-parsers  >=0.4.5
-    , cabal-plan             ^>=0.7.2
-    , containers             ^>=0.6
-    , deepseq                ^>=1.4
-    , directory              ^>=1.3.6.0
-    , filepath               ^>=1.4.2.1
-    , ghcup
-    , haskus-utils-types     ^>=1.5
-    , haskus-utils-variant   ^>=3.2.1
-    , libarchive             ^>=3.0.3.0
-    , megaparsec             >=8.0.0    && <9.3
-    , mtl                    ^>=2.2
-    , optparse-applicative   >=0.15.1.0 && <0.18
-    , pretty                 ^>=1.1.3.1
-    , pretty-terminal        ^>=0.1.0.0
-    , process                ^>=1.6.11.0
-    , resourcet              ^>=1.2.2
-    , safe                   ^>=0.3.18
-    , safe-exceptions        ^>=0.1
-    , tagsoup                ^>=0.14
-    , template-haskell       >=2.7      && <2.20
-    , temporary              ^>=1.3
-    , text                   ^>=2.0
-    , time                   ^>=1.9.3 || ^>=1.10 || ^>=1.11
-    , unordered-containers   ^>=0.2
-    , uri-bytestring         ^>=0.3.2.2
-    , utf8-string            ^>=1.0
-    , vector                 ^>=0.12
-    , versions               >=4.0.1    && <5.1
-    , yaml-streamly          ^>=0.12.0
+  build-depends: ghcup
 
   if flag(internal-downloader)
     cpp-options: -DINTERNAL_DOWNLOADER
@@ -296,8 +299,28 @@ library ghcup-optparse
 
 
 executable ghcup
+  import: app-common-depends
   main-is:            Main.hs
-
+  other-modules:
+    GHCup.OptParse
+    GHCup.OptParse.ChangeLog
+    GHCup.OptParse.Common
+    GHCup.OptParse.Compile
+    GHCup.OptParse.Config
+    GHCup.OptParse.DInfo
+    GHCup.OptParse.GC
+    GHCup.OptParse.Install
+    GHCup.OptParse.List
+    GHCup.OptParse.Nuke
+    GHCup.OptParse.Prefetch
+    GHCup.OptParse.Rm
+    GHCup.OptParse.Run
+    GHCup.OptParse.Set
+    GHCup.OptParse.Test
+    GHCup.OptParse.ToolRequirements
+    GHCup.OptParse.UnSet
+    GHCup.OptParse.Upgrade
+    GHCup.OptParse.Whereis
   hs-source-dirs:     app/ghcup
   default-language:   Haskell2010
   default-extensions:
@@ -316,41 +339,7 @@ executable ghcup
 
   build-depends:
     , ghcup-optparse
-    , aeson                  >=1.4
-    , aeson-pretty           ^>=0.8.8
-    , async                  ^>=2.2.3
-    , base                   >=4.12     && <5
-    , bytestring             >=0.10     && <0.12
-    , cabal-install-parsers  >=0.4.5
-    , cabal-plan             ^>=0.7.2
-    , containers             ^>=0.6
-    , deepseq                ^>=1.4
-    , directory              ^>=1.3.6.0
-    , filepath               ^>=1.4.2.1
     , ghcup
-    , haskus-utils-types     ^>=1.5
-    , haskus-utils-variant   ^>=3.2.1
-    , libarchive             ^>=3.0.3.0
-    , megaparsec             >=8.0.0    && <9.3
-    , mtl                    ^>=2.2
-    , optparse-applicative   >=0.15.1.0 && <0.18
-    , pretty                 ^>=1.1.3.1
-    , pretty-terminal        ^>=0.1.0.0
-    , process                ^>=1.6.11.0
-    , resourcet              ^>=1.2.2
-    , safe                   ^>=0.3.18
-    , safe-exceptions        ^>=0.1
-    , tagsoup                ^>=0.14
-    , template-haskell       >=2.7      && <2.20
-    , temporary              ^>=1.3
-    , text                   ^>=2.0
-    , time                   ^>=1.9.3 || ^>=1.10 || ^>=1.11
-    , unordered-containers   ^>=0.2
-    , uri-bytestring         ^>=0.3.2.2
-    , utf8-string            ^>=1.0
-    , vector                 ^>=0.12
-    , versions               >=4.0.1    && <5.1
-    , yaml-streamly          ^>=0.12.0
 
   if flag(internal-downloader)
     cpp-options: -DINTERNAL_DOWNLOADER
@@ -425,6 +414,7 @@ test-suite ghcup-test
 test-suite ghcup-optparse-test
   type: exitcode-stdio-1.0
   hs-source-dirs: optparse-test
+  build-tool-depends: ghcup:ghcup
   main-is: Main.hs
   default-language: Haskell2010
   ghc-options: -Wall

--- a/hie.yaml
+++ b/hie.yaml
@@ -6,3 +6,5 @@ cradle:
     path: ./app/ghcup
   - component: "ghcup:test:ghcup-test"
     path: ./test
+  - component: "ghcup:test:ghcup-optparse-test"
+    path: ./optparse-test

--- a/optparse-test/Main.hs
+++ b/optparse-test/Main.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import GHCup.OptParse as GHCup
+import Test.Tasty
+import Test.Tasty.HUnit
+import Options.Applicative
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import GHCup.Types
+import Data.Versions
+import Data.List.NonEmpty (NonEmpty ((:|)))
+
+
+main :: IO ()
+main = defaultMain setTests
+
+setTests :: TestTree
+setTests =
+  testGroup "set"
+    [ check "set" (Right $ SetOptions SetRecommended)
+    , check "set ghc" (Left $ SetGHC $ SetOptions SetRecommended)
+    , check "set ghc-9.2" (Right $ SetOptions
+        $ SetGHCVersion
+          (GHCTargetVersion (Just "ghc")
+          (mkVersion $ (Digits 9 :| []) :| [Digits 2 :| []])))
+    , check "set next" (Right $ SetOptions SetNext)
+    , check "set latest" (Right $ SetOptions $ SetToolTag Latest)
+    , check "set ghc-javascript-unknown-ghcjs-9.6"
+        (Right $ SetOptions
+          $ SetGHCVersion
+            (GHCTargetVersion
+              (Just "ghc-javascript-unknown-ghcjs")
+              (mkVersion $ (Digits 9 :| []) :| [Digits 6 :| []])
+            )
+        )
+    ]
+  where
+    check :: String -> Either SetCommand SetOptions -> TestTree
+    check args expected = testCase args $ do
+      res <- setParseWith (words args)
+      liftIO $ res @?= expected
+
+    mkVersion :: NonEmpty VChunk -> Version
+    mkVersion chunks = Version Nothing chunks [] Nothing
+
+setParseWith :: [String] -> IO (Either SetCommand SetOptions)
+setParseWith args = do
+  Set a <- parseWith args
+  pure a
+
+parseWith :: [String] -> IO Command
+parseWith args =
+  optCommand <$> handleParseResult
+    (execParserPure defaultPrefs (info GHCup.opts fullDesc) args)

--- a/optparse-test/Main.hs
+++ b/optparse-test/Main.hs
@@ -34,6 +34,23 @@ setTests =
               (mkVersion $ (Digits 9 :| []) :| [Digits 6 :| []])
             )
         )
+    , check "set next" (Right $ SetOptions SetNext)
+    , check "set nightly" (Right $ SetOptions
+        $ SetGHCVersion
+          (GHCTargetVersion
+            Nothing
+            (mkVersion $ (Str "nightly" :| []) :| [])
+          )
+        )
+    , check "set cabal-3.10"
+        (Right $ SetOptions
+          $ SetGHCVersion
+            (GHCTargetVersion
+              (Just "cabal")
+              (mkVersion $ (Digits 3 :| []) :| [Digits 10 :| []])
+            )
+        )
+    , check "set latest" (Right $ SetOptions $ SetToolTag Latest)
     ]
   where
     check :: String -> Either SetCommand SetOptions -> TestTree


### PR DESCRIPTION
This is a demo for #180.

The pr has no effect for command like `ghcup set ghc xxx`, `ghcup set cabal xxx`.

For old-style commands likes `ghcup set xxx`, it has two results. One can set ghc properly, like `ghcup set latest` and `ghcup set recommended`, and others are not, likes `ghcup set ghc-9.2`, it outputs looks like the following even if I've ghc-9.2.8 installed.

```shell
 ~ ghcup set ghc-9.2
[ Warn  ] This is an old-style command for setting GHC. Use 'ghcup set ghc' instead.
[ Warn  ] Assuming you meant version 9.2.8
[ Error ] [GHCup-00130] The version ghc-9.2.8 of the tool ghc is not installed.
```

So my solution is:

1. For scenario one, gives a warning and continue the `set` operation since they might be valid and otherwise gives an error and stop the follow-up steps.

2. For compatibility considerations, the `optparse` section is extracted to test every potential command that has the same effect during this pr.

Now it looks like:

BEFORE:

```shell
~ ghcup set ghc-9.2
[ Warn  ] This is an old-style command for setting GHC. Use 'ghcup set ghc' instead.
[ Warn  ] Assuming you meant version 9.2.8
[ Error ] [GHCup-00130] The version ghc-9.2.8 of the tool ghc is not installed.
```

AFTER:

```shell
~ cabal run ghcup -- set ghc-9.2
[ Error ] Did you mean `ghcup set ghc 9.2`?
[ ...   ]
[ ...   ]   View all candidates with `ghcup set --help`
[ ...   ]
```

BEFORE:

```shell
~ ghcup set
[ Warn  ] This is an old-style command for setting GHC. Use 'ghcup set ghc' instead.
[ Info  ] GHC 9.2.8 successfully set as default version
```

AFTER:

```shell
~ cabal run ghcup -- set 
[ Warn  ] This is an old-style command for setting GHC. Use `ghcup set ghc recommended` instead.
[ Info  ] GHC 9.2.8 successfully set as default version
```

BEFORE:

```shell
~ ghcup set latest
[ Warn  ] This is an old-style command for setting GHC. Use 'ghcup set ghc' instead.
[ Info  ] GHC 9.6.2 successfully set as default version
```

AFTER:

```shell
~ cabal run ghcup -- set latest
[ Warn  ] This is an old-style command for setting GHC. Use `ghcup set ghc latest` instead.
[ Info  ] GHC 9.6.2 successfully set as default version
```

BEFORE:

```shell
~ ghcup set ghc-javascript-unknown-ghcjs-9.6
[ Warn  ] This is an old-style command for setting GHC. Use 'ghcup set ghc' instead.
[ Warn  ] Assuming you meant version 9.6.2
[ Error ] [GHCup-00130] The version ghc-javascript-unknown-ghcjs-9.6.2 of the tool ghc is not installed.
```

AFTER:

```shell
~ cabal run ghcup -- set ghc-javascript-unknown-ghcjs-9.6
[ Error ] Did you mean `ghcup set ghc javascript-unknown-ghcjs-9.6`?
[ ...   ]
[ ...   ]   View all candidates with `ghcup set --help`
[ ...   ]
```

----

@hasufell  I'm not sure if it is worth it just for a more readable prompt. It's more appreciable if you could take a look at this before I continue improvement so I can cut losses early maybe:)