### PR TITLE
Optparse helper improvement

### DIFF
--- a/app/ghcup/GHCup/OptParse/ChangeLog.hs
+++ b/app/ghcup/GHCup/OptParse/ChangeLog.hs
@@ -75,7 +75,7 @@ changelogP =
                 e       -> Left e
               )
             )
-            (short 't' <> long "tool" <> metavar "<ghc|cabal|hls|ghcup>" <> help
+            (short 't' <> long "tool" <> metavar "<ghc|cabal|hls|ghcup|stack>" <> help
               "Open changelog for given tool (default: ghc)"
               <> completer toolCompleter
             )

--- a/app/ghcup/GHCup/OptParse/Compile.hs
+++ b/app/ghcup/GHCup/OptParse/Compile.hs
@@ -277,7 +277,7 @@ ghcCompileOpts =
             (  short 'i'
             <> long "isolate"
             <> metavar "DIR"
-            <> help "install in an isolated directory instead of the default one, no symlinks to this installation will be made"
+            <> help "install in an isolated absolute directory instead of the default one, no symlinks to this installation will be made"
             <> completer (bashCompleter "directory")
             )
            )
@@ -360,7 +360,7 @@ hlsCompileOpts =
             (  short 'i'
             <> long "isolate"
             <> metavar "DIR"
-            <> help "install in an isolated directory instead of the default one, no symlinks to this installation will be made"
+            <> help "install in an isolated absolute directory instead of the default one, no symlinks to this installation will be made"
             <> completer (bashCompleter "directory")
             )
            )

--- a/app/ghcup/GHCup/OptParse/Install.hs
+++ b/app/ghcup/GHCup/OptParse/Install.hs
@@ -196,7 +196,7 @@ installOpts tool =
            (  short 'i'
            <> long "isolate"
            <> metavar "DIR"
-           <> help "install in an isolated dir instead of the default one"
+           <> help "install in an isolated absolute directory instead of the default one"
            <> completer (bashCompleter "directory")
            )
           )

--- a/app/ghcup/GHCup/OptParse/UnSet.hs
+++ b/app/ghcup/GHCup/OptParse/UnSet.hs
@@ -113,7 +113,14 @@ unsetParser =
   unsetGHCFooter :: String
   unsetGHCFooter = [s|Discussion:
     Unsets the the current GHC version. That means there won't
-    be a ~/.ghcup/bin/ghc anymore.|]
+    be a ~/.ghcup/bin/ghc anymore.
+
+Examples:
+  # unset ghc 
+  ghcup unset ghc
+
+  # unset ghc for the target version
+  ghcup unset ghc armv7-unknown-linux-gnueabihf|]
 
   unsetCabalFooter :: String
   unsetCabalFooter = [s|Discussion:


### PR DESCRIPTION
1. Add missing stack for changelog parser
2. Extend the unset ghc optparse example to make `ghcup unset ghc [TRIPLE]` more clear.
3. Mark absolute paths if they are desired.