### PR TITLE
Fix “Invalid argument/option - 'eq'” error for the install script under PowerShell 7

### DIFF
--- a/scripts/bootstrap/bootstrap-haskell.ps1
+++ b/scripts/bootstrap/bootstrap-haskell.ps1
@@ -459,7 +459,7 @@ if (!(Test-Path -Path ('{0}' -f $MsysDir))) {
     Print-Msg -msg 'Processing MSYS2 bash for first time use...'
     Exec "$Bash" '-lc' 'exit'
 
-    Exec "$env:windir\system32\taskkill.exe" /F /FI `"MODULES eq msys-2.0.dll`"
+    Exec "$env:windir\system32\taskkill.exe" /F /FI "MODULES eq msys-2.0.dll"
 
     Print-Msg -msg 'Upgrading full system...'
     Exec "$Bash" '-lc' 'pacman --noconfirm -Syuu'


### PR DESCRIPTION
The install script doesn’t work in PowerShell 7, failing quite frustratingly midway through because line 462

    Exec "$env:windir\system32\taskkill.exe" /F /FI `"MODULES eq msys-2.0.dll`"

backquote-escapes the quotes around `taskkill`’s filter. For some ungodly reason this works fine in older PowerShell versions like the ones built into Windows, but breaks in the newer PowerShell 7.

By removing the backquotes, both old and new PowerShell works fine, so the escape was unnecessary in the first place. I hope this pull request is acceptable!