### PR TITLE
pretty-print instances for VersionRange and VersionCmp types

### DIFF
--- a/lib/GHCup/Types.hs
+++ b/lib/GHCup/Types.hs
@@ -45,7 +45,8 @@ import           Graphics.Vty                   ( Key(..) )
 import qualified Data.ByteString.Lazy          as BL
 import qualified Data.Text                     as T
 import qualified GHC.Generics                  as GHC
-
+import qualified Data.List.NonEmpty            as NE
+import           Data.Foldable                  (foldMap)
 
 #if !defined(BRICK)
 data Key = KEsc  | KChar Char | KBS | KEnter
@@ -636,6 +637,17 @@ data VersionRange = SimpleRange (NonEmpty VersionCmp) -- And
   deriving (Eq, GHC.Generic, Ord, Show)
 
 instance NFData VersionRange
+
+instance Pretty VersionCmp where
+  pPrint (VR_gt v) = text "> " <> pPrint v
+  pPrint (VR_gteq v) = text ">= " <> pPrint v
+  pPrint (VR_lt v) = text "< " <> pPrint v
+  pPrint (VR_lteq v) = text "<= " <> pPrint v
+  pPrint (VR_eq v) = text "= " <> pPrint v
+
+instance Pretty VersionRange where
+  pPrint (SimpleRange xs) = foldl1 (\x y -> x <> text " && " <> y) $ NE.map pPrint xs
+  pPrint (OrRange xs vr) = foldMap pPrint xs <> " || " <> pPrint vr
 
 instance Pretty Versioning where
   pPrint = text . T.unpack . prettyV


### PR DESCRIPTION
Adds `Pretty` type-class instances for `VersionRange` and `VersionCmp` types.

PR in response to #777 .

`ghcup-metadata` repo would use the `Pretty` instances to print out distro versions and ranges.