### PR TITLE
Fix libffi

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,7 @@ Also see [tags and shortcuts](../guide/#tags-and-shortcuts) for more information
 
 ### Linux Debian
 
-The following distro packages are required: `build-essential curl libffi-dev libffi6 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5`
+The following distro packages are required: `build-essential curl libffi-dev libffi8 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5`
 
 ### Linux Ubuntu
 


### PR DESCRIPTION
In Debian (current version is 12) libffi6 is extrimaly old and was replaced by libffi8 (see https://packages.debian.org/en/source/bookworm/libffi). May be, better way is replace it by `libffi`, that included in each version of Debian distro.