### PR TITLE
Show another cabal store path after removing GHC

### DIFF
--- a/app/ghcup/GHCup/OptParse/Common.hs
+++ b/app/ghcup/GHCup/OptParse/Common.hs
@@ -824,7 +824,7 @@ checkForUpdates = do
 
 logGHCPostRm :: (MonadReader env m, HasLog env, MonadIO m) => GHCTargetVersion -> m ()
 logGHCPostRm ghcVer = do
-  cabalStore <- liftIO $ handleIO (\_ -> if isWindows then pure "C:\\cabal\\store" else pure "~/.cabal/store")
+  cabalStore <- liftIO $ handleIO (\_ -> if isWindows then pure "C:\\cabal\\store" else pure "~/.cabal/store or ~/.local/state/cabal/store")
     (runIdentity . CC.cfgStoreDir <$> CC.readConfig)
   let storeGhcDir = cabalStore </> ("ghc-" <> T.unpack (prettyVer $ _tvVersion ghcVer))
   logInfo $ T.pack $ "After removing GHC you might also want to clean up your cabal store at: " <> storeGhcDir


### PR DESCRIPTION
https://github.com/haskell/ghcup-hs/issues/888

The whole message will be
`After removing GHC you might also want to clean up your cabal store at: ~/.cabal/store or ~/.local/state/cabal/store`

On Windows machines, the path is not different between cabal<3.10 and cabal>=3.10. Maybe related to ghcup's default InstallDir:https://github.com/haskell/ghcup-hs/blob/371eda962f713fe483616310291004a82e5b029d/scripts/bootstrap/bootstrap-haskell.ps1#L32-L33