### PR TITLE
Use absolute path to `/usr/bin/xattr` instead of pulling whatever is in `PATH`

### DIFF
--- a/lib/GHCup/Utils.hs
+++ b/lib/GHCup/Utils.hs
@@ -1033,7 +1033,7 @@ applyPatches pdir ddir = do
 
   patches <- liftIO $ quilt `catchIO` (\e ->
     if isDoesNotExistError e || isPermissionError e then
-      lexicographical 
+      lexicographical
     else throwIO e)
   forM_ patches $ \patch' -> applyPatch patch' ddir
 
@@ -1081,7 +1081,7 @@ darwinNotarization :: (MonadReader env m, HasDirs env, MonadIO m)
                    -> FilePath
                    -> m (Either ProcessError ())
 darwinNotarization Darwin path = exec
-  "xattr"
+  "/usr/bin/xattr"
   ["-r", "-d", "com.apple.quarantine", path]
   Nothing
   Nothing


### PR DESCRIPTION
Closes: #886 

On macOS systems with the [xattr](https://pypi.org/project/xattr/) Python package installed, the latter will often take precedence over the system `xattr` at `/usr/bin/xattr`. The problem is that the Python version does not support the `-r` flag to act recursively over a directory.

This commit changes the invocation of `xattr` to use the absolute path to the system version of `xattr` at `/usr/bin/xattr`.

See a similar issue for `exiftool` [here](https://github.com/exiftool/exiftool/issues/122).