### PR TITLE
Improve stack metadata support wrt #892

### DIFF
--- a/app/ghcup/BrickMain.hs
+++ b/app/ghcup/BrickMain.hs
@@ -11,7 +11,7 @@ module BrickMain where
 import           GHCup
 import           GHCup.Download
 import           GHCup.Errors
-import           GHCup.Types.Optics ( getDirs )
+import           GHCup.Types.Optics ( getDirs, getPlatformReq )
 import           GHCup.Types         hiding ( LeanAppState(..) )
 import           GHCup.Utils
 import           GHCup.OptParse.Common (logGHCPostRm)
@@ -660,8 +660,10 @@ getGHCupInfo = do
 
   r <-
     flip runReaderT settings
-    . runE @'[DigestError, ContentLengthError, GPGError, JSONError , DownloadFailed , FileDoesNotExistError]
-    $ liftE getDownloadsF
+    . runE @'[DigestError, ContentLengthError, GPGError, JSONError , DownloadFailed , FileDoesNotExistError, StackPlatformDetectError]
+    $ do
+      pfreq <- lift getPlatformReq
+      liftE $ getDownloadsF pfreq
 
   case r of
     VRight a -> pure $ Right a

--- a/data/config.yaml
+++ b/data/config.yaml
@@ -51,53 +51,45 @@ meta-cache: 300 # in seconds
 #   2. Strict: fail hard
 meta-mode: Lax # Strict | Lax
 
-# Where to get GHC/cabal/hls download info/versions from. For more detailed explanation
-# check the 'URLSource' type in the code.
+# Where to get GHC/cabal/hls download info/versions from. This is a list that performs
+# union over tool versions, preferring the later entries.
 url-source:
   ## Use the internal download uri, this is the default
-  GHCupURL: []
+  - GHCupURL
 
-  ## Example 1: Read download info from this location instead
-  ## Accepts file/http/https scheme
-  ## Can also be an array of URLs or an array of 'Either GHCupInfo URL', in
-  ## which case they are merged right-biased (overwriting duplicate versions).
-  # OwnSource: "file:///home/jule/git/ghcup-hs/ghcup-0.0.3.yaml"
+  ## Prefer stack supplied metadata (will still use GHCup metadata for versions not existing in stack metadata)
+  # - StackSetupURL
 
-  ## Example 2: Add custom tarballs to the default downloads, overwriting duplicate versions.
-  ## Can also be an array of 'Either GHCupInfo URL', also see Example 3.
-  # AddSource:
-    # Left:
-      # globalTools: {}
-      # toolRequirements: {}
-      # ghcupDownloads:
-        # GHC:
-          # 9.10.2:
-            # viTags: []
-            # viArch:
-              # A_64:
-                # Linux_UnknownLinux:
-                  # unknown_versioning:
-                    # dlUri: https://downloads.haskell.org/~ghc/7.10.3/ghc-7.10.3-x86_64-deb8-linux.tar.bz2
-                    # dlSubdir: ghc-7.10.3
-                    # dlHash: 01cfbad8dff1e8b34a5fdca8caeaf843b56e36af919e29cd68870d2588563db5
+  ## Add pre-release channel
+  # - https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml
+  ## Add nightly channel
+  # - https://ghc.gitlab.haskell.org/ghcup-metadata/ghcup-nightlies-0.0.7.yaml
+  ## Add cross compiler channel
+  # - https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-cross-0.0.8.yaml
 
-  ## Example 3: Add multiple custom download files to the default downloads via right-biased merge (overwriting duplicate
-  ## versions).
-  # AddSource:
-    # - Right: "file:///home/jule/git/ghcup-hs/ghcup-prereleases.yaml"
-    # - Right: "file:///home/jule/git/ghcup-hs/ghcup-custom.yaml"
+  ## Use dwarf bindist for 9.4.7 for ghcup metadata
+  # - ghcup-info:
+  #     ghcupDownloads:
+  #       GHC:
+  #         9.4.7:
+  #           viTags: []
+  #           viArch:
+  #             A_64:
+  #               Linux_UnknownLinux:
+  #                 unknown_versioning:
+  #                   dlUri: https://downloads.haskell.org/ghc/9.4.7/ghc-9.4.7-x86_64-deb10-linux-dwarf.tar.xz
+  #                   dlSubdir:
+  #                     RegexDir: "ghc-.*"
+  #                   dlHash: b261b3438ba455e3cf757f9c8dc3a06fdc061ea8ec287a65b7809e25fe18bad4
 
-  # For stack's setup-info, this works similar, e.g.:
-  # stack-setup-source:
-  #   AddSource:
-  #   - Left:
-  #       ghc:
-  #         linux64-tinfo6:
-  #           9.4.7:
-  #             url: "https://downloads.haskell.org/~ghc/9.4.7/ghc-9.4.7-x86_64-fedora27-linux.tar.xz"
-  #             content-length: 179117892
-  #             sha256: 216b76b7c6383e6ad9ba82533f323f8550e52893a8b9fa33c7b9dc4201ac766a
-
+  ## for stack metadata and the linux64-tinfo6 bindists, use static alpine for 9.8.1
+  # - setup-info:
+  #     ghc:
+  #       linux64-tinfo6:
+  #         9.8.1:
+  #           url: "https://downloads.haskell.org/~ghc/9.8.1/ghc-9.8.1-x86_64-alpine3_12-linux-static.tar.xz"
+  #           content-length: 229037440
+  #           sha256: b48f3d3a508d0c140d1c801e04afc65e80c0d25e7e939a8a41edb387b26b81b3
 
 # This is a way to override platform detection, e.g. when you're running
 # a Ubuntu derivate based on 18.04, you could do:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -153,8 +153,7 @@ To use a mirror, set the following option in `~/.ghcup/config.yaml`:
 
 ```yml
 url-source:
-  # Accepts file/http/https scheme
-  OwnSource: "https://some-url/ghcup-0.0.6.yaml"
+  - https://some-url/ghcup-0.0.6.yaml
 ```
 
 See [config.yaml](https://github.com/haskell/ghcup-hs/blob/master/data/config.yaml)
@@ -184,8 +183,8 @@ This will result in `~/.ghcup/config.yaml` to contain this record:
 
 ```yml
 url-source:
-  AddSource:
-  - Right: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml
+  - GHCupURL
+  - https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml
 ```
 
 You can add as many channels as you like. They are combined under *Last*, so versions from the prerelease channel
@@ -195,14 +194,13 @@ To remove the channel, delete the entire `url-source` section or set it back to 
 
 ```yml
 url-source:
-  GHCupURL: []
+  - GHCupURL
 ```
 
 If you want to combine your release channel with a mirror, you'd do it like so:
 
 ```yml
 url-source:
-  OwnSource:
   # base metadata
   - "https://mirror.sjtu.edu.cn/ghcup/yaml/ghcup/data/ghcup-0.0.6.yaml"
   # prerelease channel
@@ -249,24 +247,32 @@ stack config set system-ghc  true  --global
 ### Using stack's setup-info metadata to install GHC
 
 You can now use stack's [setup-info metadata](https://github.com/commercialhaskell/stackage-content/blob/master/stack/stack-setup-2.yaml)
-to install GHC. For that, you can invoke ghcup like so:
+to install GHC. For that, you can invoke ghcup like so as a shorthand:
 
 ```sh
-ghcup install ghc --stack-setup 9.4.7
+# ghcup will only see GHC now
+ghcup -s StackSetupURL install ghc 9.4.7
+# this combines both ghcup and stack metadata
+ghcup -s '["GHCupURL", "StackSetupURL"]' install ghc 9.4.7
 ```
 
-To make this permanent, you can add the following to you `~/.ghcup/config.yaml`:
+To make this permanent and combine it with the GHCup metadata, you can add the following to your `~/.ghcup/config.yaml`:
 
 ```yaml
-stack-setup: true
+url-source:
+  - GHCupURL
+  # stack versions take precedence
+  # you'll still have access to GHCup provided versions and tools in case they don't exist in stack metadata
+  - StackSetupURL
 ```
 
 You can customize or add sections to the setup-info similar to how the [stack documentation](https://docs.haskellstack.org/en/stable/yaml_configuration/#setup-info) explains it. E.g. to change the 9.4.7 bindist, you might do:
 
 ```yaml
-stack-setup-source:
-  AddSource:
-  - Left:
+url-source:
+  - GHCupURL
+  - StackSetupURL
+  - setup-info:
       ghc:
         linux64-tinfo6:
           9.4.7:

--- a/lib-opt/GHCup/OptParse/Prefetch.hs
+++ b/lib-opt/GHCup/OptParse/Prefetch.hs
@@ -14,6 +14,7 @@ module GHCup.OptParse.Prefetch where
 import           GHCup
 import           GHCup.Errors
 import           GHCup.Types
+import           GHCup.Types.Optics
 import           GHCup.Prelude.File
 import           GHCup.Prelude.Logger
 import           GHCup.Prelude.String.QQ
@@ -157,7 +158,9 @@ type PrefetchEffects = '[ TagNotFound
                         , GPGError
                         , DownloadFailed
                         , JSONError
-                        , FileDoesNotExistError ]
+                        , FileDoesNotExistError
+                        , StackPlatformDetectError
+                        ]
 
 
 runPrefetch :: MonadUnliftIO m
@@ -210,7 +213,8 @@ prefetch prefetchCommand runAppState runLogger =
         (v, _) <- liftE $ fromVersion mt Stack
         liftE $ fetchToolBindist (_tvVersion v) Stack pfCacheDir
       PrefetchMetadata -> do
-        _ <- liftE getDownloadsF
+        pfreq <- lift getPlatformReq
+        _ <- liftE $ getDownloadsF pfreq
         pure ""
        ) >>= \case
                 VRight _ -> do

--- a/lib/GHCup/GHC.hs
+++ b/lib/GHCup/GHC.hs
@@ -26,7 +26,6 @@ import           GHCup.Types
 import           GHCup.Types.JSON               ( )
 import           GHCup.Types.Optics
 import           GHCup.Utils
-import           GHCup.Platform
 import           GHCup.Prelude
 import           GHCup.Prelude.File
 import           GHCup.Prelude.Logger
@@ -547,14 +546,7 @@ installGHCBin :: ( MonadFail m
                    m
                    ()
 installGHCBin tver installDir forceInstall addConfArgs = do
-  Settings{ stackSetupSource, stackSetup } <- lift getSettings
-  dlinfo <- if stackSetup
-            then do
-              lift $ logInfo "Using stack's setup-info to install GHC"
-              pfreq <- lift getPlatformReq
-              keys <- liftE $ getStackPlatformKey pfreq
-              liftE $ getStackDownloadInfo stackSetupSource keys GHC tver
-            else liftE $ getDownloadInfo' GHC tver
+  dlinfo <- liftE $ getDownloadInfo' GHC tver
   liftE $ installGHCBindist dlinfo tver installDir forceInstall addConfArgs
 
 

--- a/lib/GHCup/Platform.hs
+++ b/lib/GHCup/Platform.hs
@@ -23,7 +23,7 @@ import           GHCup.Errors
 import           GHCup.Types
 import           GHCup.Types.Optics
 import           GHCup.Types.JSON               ( )
-import           GHCup.Utils
+import           GHCup.Utils.Dirs
 import           GHCup.Prelude
 import           GHCup.Prelude.Logger
 import           GHCup.Prelude.Process
@@ -348,7 +348,7 @@ getStackOSKey PlatformRequest { .. } =
     (A_ARM64, FreeBSD) -> pure "freebsd-aarch64"
     (arch', os') -> throwE $ UnsupportedSetupCombo arch' os'
 
-getStackPlatformKey :: (MonadReader env m, Alternative m, MonadFail m, HasLog env, MonadCatch m, MonadIO m)
+getStackPlatformKey :: (MonadReader env m, MonadFail m, HasLog env, MonadCatch m, MonadIO m)
                     => PlatformRequest
                     -> Excepts '[UnsupportedSetupCombo, ParseError, NoCompatiblePlatform, NoCompatibleArch, DistroNotFound, ProcessError] m [String]
 getStackPlatformKey pfreq@PlatformRequest{..} = do

--- a/lib/GHCup/Utils.hs
+++ b/lib/GHCup/Utils.hs
@@ -89,9 +89,9 @@ import qualified Data.Text.Encoding            as E
 import qualified Text.Megaparsec               as MP
 import qualified Data.List.NonEmpty            as NE
 import qualified Streamly.Prelude              as S
+
 import Control.DeepSeq (force)
 import GHC.IO (evaluate)
-import System.Environment (getEnvironment)
 import Data.Time (Day(..), diffDays, addDays)
 
 
@@ -1318,29 +1318,6 @@ warnAboutHlsCompatibility = do
 
     _ -> return ()
 
-
-
-addToPath :: [FilePath]
-          -> Bool         -- ^ if False will prepend
-          -> IO [(String, String)]
-addToPath paths append = do
- cEnv <- getEnvironment
- return $ addToPath' cEnv paths append
-
-addToPath' :: [(String, String)]
-          -> [FilePath]
-          -> Bool         -- ^ if False will prepend
-          -> [(String, String)]
-addToPath' cEnv' newPaths append =
-  let cEnv           = Map.fromList cEnv'
-      paths          = ["PATH", "Path"]
-      curPaths       = (\x -> maybe [] splitSearchPath (Map.lookup x cEnv)) =<< paths
-      {- HLINT ignore "Redundant bracket" -}
-      newPath        = intercalate [searchPathSeparator] (if append then (curPaths ++ newPaths) else (newPaths ++ curPaths))
-      envWithoutPath = foldr (\x y -> Map.delete x y) cEnv paths
-      pathVar        = if isWindows then "Path" else "PATH"
-      envWithNewPath = Map.toList $ Map.insert pathVar newPath envWithoutPath
-  in envWithNewPath
 
 
     -----------

--- a/test/optparse-test/ConfigTest.hs
+++ b/test/optparse-test/ConfigTest.hs
@@ -5,6 +5,7 @@ module ConfigTest where
 import Test.Tasty
 import Test.Tasty.HUnit
 import GHCup.OptParse
+import GHCup.Types (NewURLSource(..))
 import Utils
 import Control.Monad.IO.Class
 import URI.ByteString.QQ
@@ -23,7 +24,13 @@ checkList =
   , ("config init", InitConfig)
   , ("config show", ShowConfig)
   , ("config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml"
-    , AddReleaseChannel False [uri|https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml|]
+    , AddReleaseChannel False (NewURI [uri|https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml|])
+    )
+  , ("config add-release-channel GHCupURL"
+    , AddReleaseChannel False NewGHCupURL
+    )
+  , ("config add-release-channel StackSetupURL"
+    , AddReleaseChannel False NewStackSetupURL
     )
   , ("config set cache true", SetConfig "cache" (Just "true"))
   ]


### PR DESCRIPTION
TODO:

* [x] update docs
* [x] make sure `add-release-channel` behaves nicely

----

I kind of rewrote this... instead of adding explicit support for stack metadata to cli, I just made it accept URIs to stack setup metadata and enhanced the `URLSource` data types including its parsing.