### PR TITLE
Fix typo in ToolShadowed error for stack

### DIFF
--- a/lib/GHCup/Stack.hs
+++ b/lib/GHCup/Stack.hs
@@ -234,7 +234,7 @@ setStack ver = do
 
   liftIO (isShadowed stackbin) >>= \case
     Nothing -> pure ()
-    Just pa -> lift $ logWarn $ T.pack $ prettyHFError (ToolShadowed Cabal pa stackbin ver)
+    Just pa -> lift $ logWarn $ T.pack $ prettyHFError (ToolShadowed Stack pa stackbin ver)
 
   pure ()
 


### PR DESCRIPTION
If stack is shadowed by something, then it's `Stack` that is shadowed, not `Cabal`.

I presume this was a typo. :)