### PR TITLE
Update WASM install instructions

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -557,7 +557,7 @@ You need the required wasm toolchain:
 git clone https://gitlab.haskell.org/ghc/ghc-wasm-meta.git
 cd ghc-wasm-meta/
 export SKIP_GHC=yes
-sh setup.sh
+./setup.sh
 source ~/.ghc-wasm/env
 ```
 


### PR DESCRIPTION
I tried to install the cross bindists for the JS and WASM backends on a GitHub action. Everything worked fine, except for `sh setup.sh`, which produced the following error:
```sh
setup.sh: 3: set: Illegal option -o pipefail
```
Changing the line to `./setup.sh` fixes the issue.