### PR TITLE
Improve NoDownload Pretty instance on missing/unknown "mtarget"

### DIFF
--- a/lib/GHCup/Errors.hs
+++ b/lib/GHCup/Errors.hs
@@ -389,7 +389,7 @@ data NotInstalled = NotInstalled Tool GHCTargetVersion
 
 instance Pretty NotInstalled where
   pPrint (NotInstalled tool ver) =
-    text "The version" <+> pPrint ver <+> text "of the tool" <+> pPrint tool <+> text "is not installed."
+    text "The version" <+> (text "'" <> pPrint ver <> text "'") <+> text "of the tool" <+> pPrint tool <+> text "is not installed."
 
 instance HFErrorProject NotInstalled where
   eBase _ = 130

--- a/lib/GHCup/Errors.hs
+++ b/lib/GHCup/Errors.hs
@@ -212,20 +212,22 @@ data NoDownload = NoDownload GHCTargetVersion Tool (Maybe PlatformRequest)
   deriving Show
 
 instance Pretty NoDownload where
-  pPrint (NoDownload tver@(GHCTargetVersion mtarget vv) tool mpfreq)
-    | (Just target) <- mtarget
-    , target `elem` (T.pack . prettyShow <$> enumFromTo (minBound :: Tool) (maxBound :: Tool))
-    = text $ "Unable to find a download for "
+  pPrint (NoDownload tver@(GHCTargetVersion mtarget vv) tool mpfreq) =
+    let helperMsg
+          | (Just target) <- mtarget
+          , target `elem` (T.pack . prettyShow <$> enumFromTo (minBound :: Tool) (maxBound :: Tool)) =
+              "\nPerhaps you meant: 'ghcup <command> "
+              <> T.unpack target
+              <> " "
+              <> T.unpack (prettyVer vv)
+              <> "'"
+          | otherwise = ""
+    in text $ "Unable to find a download for "
              <> show tool
-             <> " version '"
-             <> T.unpack (tVerToText tver)
-             <> maybe "'\n" (\pfreq -> "' on detected platform " <> pfReqToString pfreq <> "\n") mpfreq
-             <> "Perhaps you meant: 'ghcup <command> "
-             <> T.unpack target
-             <> " "
-             <> T.unpack (prettyVer vv)
-             <> "'"
-    | otherwise = text $ "Unable to find a download for " <> T.unpack (tVerToText tver)
+             <> " version "
+             <> "'" <> T.unpack (tVerToText tver) <> "'"
+             <> maybe "" (\pfreq -> " on detected platform " <> pfReqToString pfreq) mpfreq
+             <> helperMsg
 
 instance HFErrorProject NoDownload where
   eBase _ = 10


### PR DESCRIPTION
The guard was only used for the "Perhaps you meant"-part, so include the other part regardless of what `mtarget` is.

Also: quote the version in the NotInstalled Pretty instance, so it matches that of the NoDownload Pretty instance.

Fixes #957