### PR TITLE
Use STACK_XDG env to determine the stack root path

### DIFF
--- a/scripts/bootstrap/bootstrap-haskell
+++ b/scripts/bootstrap/bootstrap-haskell
@@ -738,6 +738,15 @@ ask_stack() {
 	unset stack_answer
 }
 
+find_stack_root() {
+    if [ -n "${STACK_ROOT}" ] ; then
+        echo "${STACK_ROOT}"
+    elif [ -n "${STACK_XDG}" ] ; then
+        echo "${XDG_DATA_HOME}/stack"
+    else
+        echo "${HOME}/.stack"
+    fi
+}
 
 find_shell
 
@@ -850,8 +859,9 @@ case $ask_stack_answer in
 		;;
 	2)
         (_eghcup --cache install stack) || die "Stack installation failed"
-        edo mkdir -p "${STACK_ROOT:-$HOME/.stack}"/hooks
-        hook_exe="${STACK_ROOT:-$HOME/.stack}"/hooks/ghc-install.sh
+        stack_root="$(find_stack_root)"
+        edo mkdir -p "${stack_root}"/hooks
+        hook_exe="${stack_root}"/hooks/ghc-install.sh
         hook_url="https://www.haskell.org/ghcup/sh/hooks/stack/ghc-install.sh"
 
         if [ -e "${hook_exe}" ] ; then

--- a/scripts/bootstrap/bootstrap-haskell
+++ b/scripts/bootstrap/bootstrap-haskell
@@ -742,7 +742,7 @@ find_stack_root() {
     if [ -n "${STACK_ROOT}" ] ; then
         echo "${STACK_ROOT}"
     elif [ -n "${STACK_XDG}" ] ; then
-        echo "${XDG_DATA_HOME}/stack"
+        echo "${XDG_DATA_HOME:-$HOME/.local/share}/stack"
     else
         echo "${HOME}/.stack"
     fi


### PR DESCRIPTION
During installation, a hook script is copied to the hooks directory under _stack_'s root path.  The aim is to provide a better integration between _ghcup_ and _stack_.  

Currently, the installation script only considers the `STACK_ROOT` env variable to determine _stack_'s root path.  _Stack_, however, can also be configured to follow the XDG base directory specification by setting the `STACK_XDG` env, as explained [here](https://docs.haskellstack.org/en/stable/stack_root/).

For people using _stack_ with the XDG base directory specification, the hook script ends up being copied in the default _stack_'s root path, i.e. in `${HOME}/.stack`, resulting in a lack of integration between _ghcup_ and _stack_.

This change takes into account the `STACK_XDG` env to determine the proper _stack_ root path. 