### PR TITLE
GHCup Website Top Bar

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,8 +1,8 @@
 :root {
   --theme-purple: #5E5184;
   --theme-purple-dark: rgba(69, 59, 97, 0.5);
-  --ukraine-top: #0057B8;
-  --ukraine-bottom: #FFD700;
+  --ukraine-top: #E4312B;
+  --ukraine-bottom: #149954;
   --link-pink: #9E358F;
 }
 


### PR DESCRIPTION
I like watermelons. [153 UN Member countries](https://press.un.org/en/2023/ga12572.doc.htm) also like watermelons. This PR would make the top color scheme for the GHCup website red and green. Of course, I do not mean to draw attention away from the suffering of any particular group, but there can only be one color scheme sadly. This just happens to be highly relevant at the moment.

This change would likely annoy some people, but most things worth doing get some amount of pushback.