### PR TITLE
Remove `includes` from `.cabal`-file

### DIFF
--- a/ghcup.cabal
+++ b/ghcup.cabal
@@ -260,7 +260,6 @@ library
 
     exposed-modules:  GHCup.Prelude.File.Posix.Traversals
     include-dirs:     cbits
-    includes:         dirutils.h
     install-includes: dirutils.h
     c-sources:        cbits/dirutils.c
     build-depends:


### PR DESCRIPTION
This is useless at best, and a common source of confusion.

https://github.com/haskell/cabal/pull/10145
https://github.com/sol/hpack/issues/355