### PR TITLE
Update haskellstack.org URLs for change to its structure

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -273,7 +273,7 @@ You don't need to. However, some users seem to prefer to have a central tool tha
 at the same time. Additionally, it can allow better sharing of GHC installation across these tools.
 Also see:
 
-* https://docs.haskellstack.org/en/stable/yaml_configuration/#system-ghc
+* https://docs.haskellstack.org/en/stable/configure/yaml/non-project/#system-ghc
 * https://github.com/commercialhaskell/stack/pull/5585
 
 ### Why does ghcup not use stack code?

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -245,7 +245,8 @@ GHC versions there are two strategies.
 
 ### Strategy 1: Stack hooks (new, recommended)
 
-Since stack 2.9.1 you can customize the installation logic of GHC completely, see [https://docs.haskellstack.org/en/stable/yaml_configuration/#ghc-installation-customisation](https://docs.haskellstack.org/en/stable/yaml_configuration/#ghc-installation-customisation).
+Since stack 2.9.1 you can customize the installation logic of GHC completely, see
+[https://docs.haskellstack.org/en/stable/configure/customisation_scripts/#ghc-installation-customisation](https://docs.haskellstack.org/en/stable/configure/customisation_scripts/#ghc-installation-customisation).
 
 We can use this to simply invoke ghcup whenever stack is trying to install/discover a GHC versions. This
 is done via placing a shell script at `~/.stack/hooks/ghc-install.sh` and making it executable.
@@ -297,7 +298,9 @@ url-source:
   - StackSetupURL
 ```
 
-You can customize or add sections to the setup-info similar to how the [stack documentation](https://docs.haskellstack.org/en/stable/yaml_configuration/#setup-info) explains it. E.g. to change the 9.4.7 bindist, you might do:
+You can customize or add sections to the setup-info similar to how the
+[stack documentation](https://docs.haskellstack.org/en/stable/configure/yaml/non-project/#setup-info)
+explains it. E.g. to change the 9.4.7 bindist, you might do:
 
 ```yaml
 url-source:
@@ -341,7 +344,8 @@ extra-include-dirs:
 - C:\ghcup\msys64\mingw64\include
 ```
 
-Also check out: [https://docs.haskellstack.org/en/stable/yaml_configuration](https://docs.haskellstack.org/en/stable/yaml_configuration)
+Also check out:
+[https://docs.haskellstack.org/en/stable/configure/yaml/non-project](https://docs.haskellstack.org/en/stable/configure/yaml/non-project)
 
 ## Mirrors (proper)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -421,7 +421,7 @@ The developers of the Haskell Language Server offer an [extension](https://githu
 1. Install GHCup. During installation, opt in to install the Haskell Language Server (HLS).
 2. Install the extension (from VSCode: Ctrl + P and then `ext install haskell.haskell`).
 3. Make sure your project uses the GHC version installed from GHCup (otherwise HLS is likely to fail on launch):
-    - instructions for [stack](https://docs.haskellstack.org/en/stable/yaml_configuration/#system-ghc)
+    - instructions for [stack](https://docs.haskellstack.org/en/stable/configure/yaml/non-project/#system-ghc)
 
 On Linux, some users have reported an issue when VSCode is not launched from a terminal ("cannot find ghc version"). A solution is to [let HLS know about your GHCup on $PATH](https://github.com/haskell/vscode-haskell#stackcabalghc-can-not-be-found).
 
@@ -431,4 +431,3 @@ On Linux, some users have reported an issue when VSCode is not launched from a t
 * [GHCup issue tracker](https://github.com/haskell/ghcup-hs/issues/new)
 * [Matrix](https://matrix.to/#/#ghcup:matrix.org)
 * [Discord](https://discord.gg/WDqsWsnZfR)
-

--- a/scripts/bootstrap/bootstrap-haskell
+++ b/scripts/bootstrap/bootstrap-haskell
@@ -749,7 +749,7 @@ ask_stack() {
 		warn "Do you want to enable better integration of stack with GHCup?"
         warn "This means that stack won't install its own GHC versions, but uses GHCup's."
         warn "For more information see:"
-        warn "  https://docs.haskellstack.org/en/stable/yaml_configuration/#ghc-installation-customisation-experimental"
+        warn "  https://docs.haskellstack.org/en/stable/configure/customisation_scripts/#ghc-installation-customisation"
         warn "If you want to keep stacks vanilla behavior, answer 'No'."
 		warn ""
 		warn "[Y] Yes  [N] No  [?] Help (default is \"Y\")."

--- a/scripts/hooks/stack/ghc-install.sh
+++ b/scripts/hooks/stack/ghc-install.sh
@@ -2,7 +2,7 @@
 
 # !! KEEP THIS SCRIPT POSIX COMPLIANT !!
 
-# see https://docs.haskellstack.org/en/stable/yaml_configuration/#ghc-installation-customisation-experimental
+# see https://docs.haskellstack.org/en/stable/configure/customisation_scripts/#ghc-installation-customisation
 # for documentation about hooks
 
 set -eu


### PR DESCRIPTION
Stack has recently updated the structure of its web site. This updates URLs, like for like.