### PR TITLE
Print aeson decoding error when metadata decoding fails

### DIFF
--- a/lib/GHCup/Download.hs
+++ b/lib/GHCup/Download.hs
@@ -158,8 +158,8 @@ getDownloadsF pfreq@(PlatformRequest arch plat _) = do
   dl' (NewSetupInfo si) = pure (Right si)
   dl' (NewURI uri)      = do
                             base <- liftE $ getBase uri
-                            catchE @JSONError (\(JSONDecodeError _) -> do
-                                logDebug $ "Couldn't decode " <> T.pack base <> " as GHCupInfo, trying as SetupInfo: "
+                            catchE @JSONError (\(JSONDecodeError s) -> do
+                                logDebug $ "Couldn't decode " <> T.pack base <> " as GHCupInfo, trying as SetupInfo: " <> T.pack s
                                 Right <$> decodeMetadata @Stack.SetupInfo base)
                               $ fmap Left (decodeMetadata @GHCupInfo base >>= \gI -> warnOnMetadataUpdate uri gI >> pure gI)
 


### PR DESCRIPTION
Previously the reported error is misleading

```
[ Info  ] downloading: https://ghc.gitlab.haskell.org/ghcup-metadata/ghcup-nightlies-0.0.7.yaml as file /Users/bchinn/.ghcup/cache/ghcup-nightlies-0.0.7.yaml
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  606k  100  606k    0     0   964k      0 --:--:-- --:--:-- --:--:--  963k
[ Error ] [GHCup-00160] JSON decoding failed with: Aeson exception:
[ ...   ] Error in $: key "ghc" not found
[ ...   ] Consider removing /Users/bchinn/.ghcup/cache/ghcup-nightlies-0.0.7.yaml manually.
```

because this is the error when trying to decode the metadata as a stack format.

The actual error is much better:

```
[ Debug ] Identified Platform as: Linux UnknownLinux, 24.05
[ Debug ] using local file: /home/matt/ghcup-hs/ghcup-nightlies-0.0.7.yaml
[ Debug ] Decoding yaml at: /home/matt/ghcup-hs/ghcup-nightlies-0.0.7.yaml
[ Debug ] Couldn't decode /home/matt/ghcup-hs/ghcup-nightlies-0.0.7.yaml as GHCupInfo, trying as SetupInfo: Aeson exception:
[ ...   ] Error in $.ghcupDownloads.GHC['9.11.20240719'].viArch['A_32']['Linux_Debian']['unknown versioning']: Failure in (Maybe VersionRange) (FromJSONKey)1:16:
[ ...   ]   |
[ ...   ] 1 | unknown versioning
[ ...   ]   |                ^
[ ...   ] unexpected 'v'
[ ...   ] expecting end of input or white space
[ ...   ]
[ ...   ] Consider removing /home/matt/ghcup-hs/ghcup-nightlies-0.0.7.yaml manually.
[ Debug ] Decoding yaml at: /home/matt/ghcup-hs/ghcup-nightlies-0.0.7.yaml
[ Error ] [GHCup-00160] JSON decoding failed with: Aeson exception:
[ ...   ] Error in $: key "ghc" not found
[ ...   ] Consider removing /home/matt/ghcup-hs/ghcup-nightlies-0.0.7.yaml manually.
```

Perhaps the fallback mechanism is a bit confusing and it would be better to have different command line options for ghcup/stack metadata. The bad error will still be reported to a user if they encounter malformed metadata.