### PR TITLE
Fix `list --hide-old` in-app help message

### DIFF
--- a/lib-opt/GHCup/OptParse/List.hs
+++ b/lib-opt/GHCup/OptParse/List.hs
@@ -107,7 +107,7 @@ listOpts =
             )
           )
     <*> switch
-          (short 'o' <> long "hide-old" <> help "Hide 'old' GHC versions (installed ones are always shown)"
+          (short 'o' <> long "hide-old" <> help "Hide 'old' tool versions (installed ones are always shown)"
           )
     <*> switch
           (short 'n' <> long "show-nightly" <> help "Show nightlies (installed ones are always shown)"


### PR DESCRIPTION
`--hide-old` not limited in its effect to GHC versions.