### PR TITLE
stack.yaml: Remove spurious flags

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -72,9 +72,6 @@ flags:
   mintty:
     win32-2-13-1: true
 
-  ansi-terminal:
-    win32-2-13-1: true
-
 ghc-options:
   "$locals": -O2
   ghcup: -O2 -fspec-constr-recursive=16 -fmax-worker-args=16


### PR DESCRIPTION
b9adc1f accidentally added `win32-2-13-1: true` to `ansi-terminal` as well. Stack complains that no such flag exists, preventing building.