### PR TITLE
Add multi-user install support in windows bootstrap

### DIFF
--- a/scripts/bootstrap/bootstrap-haskell.ps1
+++ b/scripts/bootstrap/bootstrap-haskell.ps1
@@ -49,7 +49,7 @@ param (
     [switch]$DontAdjustBashRc,
     # The msys2 environment to use, see https://www.msys2.org/docs/environments/ (defauts to MINGW64, MINGW32 or CLANGARM64, depending on the architecture)
     [string]$Msys2Env,
-    # Do a multi-user install (requires administrative previlidges to modify system PATH env)
+    # Do a multi-user install (requires administrative privileges to modify system PATH env)
     [switch]$MultiUserInstall
 )
 

--- a/scripts/bootstrap/bootstrap-haskell.ps1
+++ b/scripts/bootstrap/bootstrap-haskell.ps1
@@ -675,6 +675,7 @@ if ($Host.Name -eq "ConsoleHost")
 $Container = 'User'
 if ($MultiUserInstall) {
   Print-Msg -msg ('Adding {0}\bin to System Path...' -f $GhcupDir)
+  Print-Msg -msg ('Other users that are currently signed in will have to sign out and login again to use ghcup')
   $Container = 'Machine'
 } else {
   Print-Msg -msg ('Adding {0}\bin to Users Path...' -f $GhcupDir)


### PR DESCRIPTION
By setting up the env vars at the "Machine" level.

If there are other users currently logged in, they will have to sign out and login again for the global env vars to take effect.