### PR TITLE
Allow GHCup to build & run on OpenBSD

### DIFF
--- a/cabal.project.release
+++ b/cabal.project.release
@@ -2,9 +2,10 @@ import: cabal.project.common
 
 optimization: 2
 
--- The release project file always wants to build with -tar.
--- The tar flag is only there to circumvent complicated errors during
--- development, which sometimes happens due to libarchive.
+-- The release project file always wants to build with -tar on the
+-- platforms it supports (which are those it provides config.h files
+-- for). The tar flag is only there to circumvent complicated errors
+-- during development, which sometimes happens due to libarchive.
 package ghcup
     flags: +tui
 
@@ -32,3 +33,6 @@ elif os(freebsd)
                xz -system-xz
   package *
     ghc-options: -split-sections
+else
+  package ghcup
+    flags: +tar

--- a/lib-opt/GHCup/OptParse/ChangeLog.hs
+++ b/lib-opt/GHCup/OptParse/ChangeLog.hs
@@ -136,6 +136,7 @@ changelog ChangeLogOptions{..} runAppState runLogger = do
               Darwin  -> exec "open" [T.unpack $ decUTF8Safe $ serializeURIRef' uri] Nothing Nothing
               Linux _ -> exec "xdg-open" [T.unpack $ decUTF8Safe $ serializeURIRef' uri] Nothing Nothing
               FreeBSD -> exec "xdg-open" [T.unpack $ decUTF8Safe $ serializeURIRef' uri] Nothing Nothing
+              OpenBSD -> exec "xdg-open" [T.unpack $ decUTF8Safe $ serializeURIRef' uri] Nothing Nothing
               Windows -> do
                 let args = "start \"\" " ++ (T.unpack $ decUTF8Safe $ serializeURIRef' uri)
                 c <- liftIO $ system $ args

--- a/lib/GHCup/Types.hs
+++ b/lib/GHCup/Types.hs
@@ -227,6 +227,7 @@ data Platform = Linux LinuxDistro
               | Darwin
               -- ^ must exit
               | FreeBSD
+              | OpenBSD
               | Windows
               -- ^ must exit
   deriving (Eq, GHC.Generic, Ord, Show)
@@ -237,6 +238,7 @@ platformToString :: Platform -> String
 platformToString (Linux distro) = "linux-" ++ distroToString distro
 platformToString Darwin = "darwin"
 platformToString FreeBSD = "freebsd"
+platformToString OpenBSD = "openbsd"
 platformToString Windows = "windows"
 
 instance Pretty Platform where

--- a/lib/GHCup/Types/JSON.hs
+++ b/lib/GHCup/Types/JSON.hs
@@ -144,12 +144,14 @@ instance ToJSONKey Platform where
     FreeBSD -> T.pack "FreeBSD"
     Linux (OtherLinux s) -> T.pack ("Linux_" <> s)
     Linux d -> T.pack ("Linux_" <> show d)
+    OpenBSD -> T.pack "OpenBSD"
     Windows -> T.pack "Windows"
 
 instance FromJSONKey Platform where
   fromJSONKey = FromJSONKeyTextParser $ \t -> if
     | T.pack "Darwin" == t -> pure Darwin
     | T.pack "FreeBSD" == t -> pure FreeBSD
+    | T.pack "OpenBSD" == t -> pure OpenBSD
     | T.pack "Windows" == t -> pure Windows
     | T.pack "Linux_" `T.isPrefixOf` t -> case
         T.stripPrefix (T.pack "Linux_") t


### PR DESCRIPTION
Fix #707.

This doesn't ensure that GHCup's GHC build scripts/manifests work for OpenBSD, merely that it itself builds and runs on OpenBSD.