### PR TITLE
Allow specifying a custom version in advance install menu

### DIFF
--- a/lib-tui/GHCup/Brick/Common.hs
+++ b/lib-tui/GHCup/Brick/Common.hs
@@ -48,7 +48,7 @@ module GHCup.Brick.Common  (
     , BuildFlavourEditBox, BuildSystemEditBox, OkButton, AdvanceInstallButton
     , CompileGHCButton, CompileHLSButton, CabalProjectEditBox
     , CabalProjectLocalEditBox, UpdateCabalCheckBox, GitRefEditBox
-    , BootstrapGhcSelectBox, HadrianGhcSelectBox
+    , BootstrapGhcSelectBox, HadrianGhcSelectBox, ToolVersionBox
   ) ) where
 
 import           GHCup.List ( ListResult )
@@ -132,6 +132,9 @@ pattern BootstrapGhcSelectBox :: ResourceId
 pattern BootstrapGhcSelectBox = ResourceId 21
 pattern HadrianGhcSelectBox :: ResourceId
 pattern HadrianGhcSelectBox = ResourceId 22
+
+pattern ToolVersionBox :: ResourceId
+pattern ToolVersionBox = ResourceId 23
 
 -- | Name data type. Uniquely identifies each widget in the TUI.
 -- some constructors might end up unused, but still is a good practise


### PR DESCRIPTION
This field is necessary as the user may be installing some arbitrary version using a URI, and there is no way to specify a version for that, (like the command line `ghcup install -u <uri> <version>` supports.)

The `GHCTargetVersion` used for `instVersion` is not ideal for handling installation of other tools, but since we have a single AdvanceInstall menu shared for all tools, I think its ok to use this to avoid a bigger change to the code.