### PR TITLE
More beef for debug-info

### DIFF
--- a/lib-opt/GHCup/OptParse/DInfo.hs
+++ b/lib-opt/GHCup/OptParse/DInfo.hs
@@ -79,9 +79,9 @@ prettyDebugInfo DebugInfo { diDirs = Dirs { .. }, ..} =
   "logs: " <> fromGHCupPath logsDir <> "\n" <>
   "config: " <> fromGHCupPath confDir <> "\n" <>
   "db: " <> fromGHCupPath dbDir <> "\n" <>
-  "recycle: " <> fromGHCupPath recycleDir <> "\n" <>
+  (if isWindows then ("recycle: " <> fromGHCupPath recycleDir <> "\n") else mempty) <>
   "temp: " <> fromGHCupPath tmpDir <> "\n" <>
-  "msys2: " <> msys2Dir <> "\n" <>
+  (if isWindows then ("msys2: " <> msys2Dir <> "\n") else mempty) <>
   "\n===== Metadata ======\n" <>
   intercalate "\n" ((\(c, u) -> (T.unpack . channelAliasText) c <> ": " <> (T.unpack . decUTF8Safe . serializeURIRef') u) <$> diChannels)
 

--- a/lib-opt/GHCup/OptParse/DInfo.hs
+++ b/lib-opt/GHCup/OptParse/DInfo.hs
@@ -29,11 +29,14 @@ import           Control.Monad.Reader
 import           Control.Monad.Trans.Resource
 import           Data.Functor
 import           Data.Maybe
+import           Data.List                      ( intercalate )
 import           Data.Variant.Excepts
 import           Options.Applicative     hiding ( style )
 import           Prelude                 hiding ( appendFile )
 import           System.Exit
+import           System.FilePath
 import           Text.PrettyPrint.HughesPJClass ( prettyShow )
+import           URI.ByteString (serializeURIRef')
 
 import qualified Data.Text                     as T
 import Control.Exception.Safe (MonadMask)
@@ -63,15 +66,25 @@ describe_result = $( LitE . StringL <$>
 
 
 prettyDebugInfo :: DebugInfo -> String
-prettyDebugInfo DebugInfo {..} = "Debug Info" <> "\n" <>
-  "==========" <> "\n" <>
-  "GHCup base dir: " <> diBaseDir <> "\n" <>
-  "GHCup bin dir: " <> diBinDir <> "\n" <>
-  "GHCup GHC directory: " <> diGHCDir <> "\n" <>
-  "GHCup cache directory: " <> diCacheDir <> "\n" <>
+prettyDebugInfo DebugInfo { diDirs = Dirs { .. }, ..} =
+  "===== Main ======" <> "\n" <>
   "Architecture: " <> prettyShow diArch <> "\n" <>
   "Platform: " <> prettyShow diPlatform <> "\n" <>
-  "Version: " <> describe_result
+  "GHCup Version: " <> describe_result <> "\n" <>
+  "===== Directories ======" <> "\n" <>
+  "base: " <> fromGHCupPath baseDir <> "\n" <>
+  "bin: " <> binDir <> "\n" <>
+  "GHCs: " <> (fromGHCupPath baseDir </> "ghc") <> "\n" <>
+  "cache: " <> fromGHCupPath cacheDir <> "\n" <>
+  "logs: " <> fromGHCupPath logsDir <> "\n" <>
+  "config: " <> fromGHCupPath confDir <> "\n" <>
+  "db: " <> fromGHCupPath dbDir <> "\n" <>
+  "recycle: " <> fromGHCupPath recycleDir <> "\n" <>
+  "temp: " <> fromGHCupPath tmpDir <> "\n" <>
+  "msys2: " <> msys2Dir <> "\n" <>
+  "\n===== Metadata ======\n" <>
+  intercalate "\n" ((\(c, u) -> (T.unpack . channelAliasText) c <> ": " <> (T.unpack . decUTF8Safe . serializeURIRef') u) <$> diChannels)
+
 
 
 

--- a/lib/GHCup.hs
+++ b/lib/GHCup.hs
@@ -258,11 +258,9 @@ getDebugInfo :: ( Alternative m
                   m
                   DebugInfo
 getDebugInfo = do
-  Dirs {..} <- lift getDirs
-  let diBaseDir  = fromGHCupPath baseDir
-  let diBinDir   = binDir
-  diGHCDir       <- fromGHCupPath <$> lift ghcupGHCBaseDir
-  let diCacheDir = fromGHCupPath cacheDir
+  diDirs <- lift getDirs
+  let diChannels = fmap (\c -> (c, channelURL c)) [minBound..maxBound]
+  let diShimGenURL = shimGenURL
   diArch         <- lE getArchitecture
   diPlatform     <- liftE getPlatform
   pure $ DebugInfo { .. }

--- a/lib/GHCup/Types.hs
+++ b/lib/GHCup/Types.hs
@@ -666,12 +666,11 @@ data GPGSetting = GPGStrict
 instance NFData GPGSetting
 
 data DebugInfo = DebugInfo
-  { diBaseDir  :: FilePath
-  , diBinDir   :: FilePath
-  , diGHCDir   :: FilePath
-  , diCacheDir :: FilePath
-  , diArch     :: Architecture
-  , diPlatform :: PlatformResult
+  { diDirs       :: Dirs
+  , diArch       :: Architecture
+  , diPlatform   :: PlatformResult
+  , diChannels   :: [(ChannelAlias, URI)]
+  , diShimGenURL :: URI
   }
   deriving Show
 


### PR DESCRIPTION
```
===== Main ======
Architecture: x86_64
Platform: Linux OpenSUSE, 20250109
GHCup Version: v0.1.40.0-20-g6faafefb

===== Directories ======
base: /home/hasufell/.ghcup
bin: /home/hasufell/.ghcup/bin
GHCs: /home/hasufell/.ghcup/ghc
cache: /home/hasufell/.ghcup/cache
logs: /home/hasufell/.ghcup/logs
config: /home/hasufell/.ghcup
db: /home/hasufell/.ghcup/db
recycle: /home/hasufell/.ghcup/trash
temp: /home/hasufell/.ghcup/tmp
msys2: /home/hasufell/.ghcup/msys64

===== Metadata ======
default: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-0.0.9.yaml
stack: https://raw.githubusercontent.com/commercialhaskell/stackage-content/master/stack/stack-setup-2.yaml
cross: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-cross-0.0.9.yaml
prereleases: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.9.yaml
vanilla: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-vanilla-0.0.9.yaml
```