### PR TITLE
Missing space after "stray directory"

### DIFF
--- a/lib/GHCup/List.hs
+++ b/lib/GHCup/List.hs
@@ -183,7 +183,7 @@ listVersions lt' criteria hideOld showNightly days = do
               }
       Left e -> do
         logWarn
-          $ "Could not parse version of stray directory" <> T.pack e
+          $ "Could not parse version of stray directory " <> T.pack e
         pure Nothing
 
   strayCabals :: ( MonadReader env m
@@ -218,7 +218,7 @@ listVersions lt' criteria hideOld showNightly days = do
               }
       Left e -> do
         logWarn
-          $ "Could not parse version of stray directory" <> T.pack e
+          $ "Could not parse version of stray directory " <> T.pack e
         pure Nothing
 
   strayHLS :: ( MonadReader env m
@@ -252,7 +252,7 @@ listVersions lt' criteria hideOld showNightly days = do
               }
       Left e -> do
         logWarn
-          $ "Could not parse version of stray directory" <> T.pack e
+          $ "Could not parse version of stray directory " <> T.pack e
         pure Nothing
 
   strayStacks :: ( MonadReader env m
@@ -287,7 +287,7 @@ listVersions lt' criteria hideOld showNightly days = do
               }
       Left e -> do
         logWarn
-          $ "Could not parse version of stray directory" <> T.pack e
+          $ "Could not parse version of stray directory " <> T.pack e
         pure Nothing
 
   currentGHCup :: Map.Map GHCTargetVersion VersionInfo -> Maybe ListResult


### PR DESCRIPTION
Fixing this garbled message:
> [ Warn  ] Could not parse version of stray directorystack-2.7.5.exe.tmp

P.S. Ever heard about cut-and-paste programming? :-D