### PR TITLE
Use upstream uri-bytestring

### DIFF
--- a/cabal.project.common
+++ b/cabal.project.common
@@ -25,12 +25,6 @@ if os(mingw32)
   if impl(ghc >= 9.4)
     constraints: language-c >= 0.9.3
 
-
-source-repository-package
-  type: git
-  location: https://github.com/hasufell/uri-bytestring.git
-  tag: 4fb5ed14b500c192e6e7a97f6b2b1eb478806001
-
 package libarchive
   flags: -system-libarchive
 

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,0 @@
-index-state: hackage.haskell.org 2024-12-03T03:14:47Z

--- a/ghcup.cabal
+++ b/ghcup.cabal
@@ -119,7 +119,7 @@ common app-common-depends
     , text                   ^>=2.0 || ^>=2.1
     , time                   >=1.9.3    && <1.15
     , unordered-containers   ^>=0.2
-    , uri-bytestring         ^>=0.3.2.2
+    , uri-bytestring         ^>=0.4.0.0
     , utf8-string            ^>=1.0
     , vector                 >=0.12     && <0.14
     , versions               >=6.0.5      && <6.1
@@ -251,7 +251,7 @@ library
     , transformers          ^>=0.5 || ^>=0.6
     , unliftio-core         ^>=0.2.0.1
     , unordered-containers  ^>=0.2.10.0
-    , uri-bytestring        ^>=0.3.2.2
+    , uri-bytestring        ^>=0.4.0.0
     , utf8-string           ^>=1.0
     , vector                 >=0.12     && <0.14
     , versions               >=6.0.5      && <6.1
@@ -494,7 +494,7 @@ test-suite ghcup-test
     , quickcheck-arbitrary-adt  ^>=0.3.1.0
     , text                      ^>=2.0 || ^>=2.1
     , time                      >=1.9.3   && <1.15
-    , uri-bytestring            ^>=0.3.2.2
+    , uri-bytestring            ^>=0.4.0.0
     , versions                   >=6.0.5      && <6.1
 
   if os(windows)

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,9 +13,8 @@ extra-deps:
   - variant-1.0@sha256:a3c819560424f59285a09f3ebd762f3a328163d109b5da55c4c54b6626f58c97,2180
   - xz-5.6.3
   - zlib-0.6.3.0@sha256:96d388c95a98d6db94b74053130c00aea3c8c8ee041b5594bbe09242f1714356,5465
+  - uri-bytestring-0.4.0.0
   - xz-clib-5.6.3
-  - github: hasufell/uri-bytestring
-    commit: 4fb5ed14b500c192e6e7a97f6b2b1eb478806001
 
 allow-newer: true
 


### PR DESCRIPTION
It's fixed now:
  https://github.com/Soostone/uri-bytestring/pull/64#issuecomment-2606030276