### PR TITLE
Make --tool and --show-criteria 'many'

### DIFF
--- a/lib-opt/GHCup/OptParse/Common.hs
+++ b/lib-opt/GHCup/OptParse/Common.hs
@@ -322,7 +322,7 @@ versionCompleter' criteria tool filter' = listIOCompleter $ do
 
           runEnv = flip runReaderT appState
 
-      installedVersions <- runEnv $ listVersions (Just tool) criteria False False (Nothing, Nothing)
+      installedVersions <- runEnv $ listVersions [tool] criteria False False (Nothing, Nothing)
       return $ fmap (T.unpack . prettyVer) . filter filter' . fmap lVer $ installedVersions
 
 
@@ -481,7 +481,7 @@ checkForUpdates :: ( MonadReader env m
                 => m [(Tool, GHCTargetVersion)]
 checkForUpdates = do
   GHCupInfo { _ghcupDownloads = dls } <- getGHCupInfo
-  lInstalled <- listVersions Nothing [ListInstalled True] False False (Nothing, Nothing)
+  lInstalled <- listVersions [] [ListInstalled True] False False (Nothing, Nothing)
   let latestInstalled tool = (fmap (\lr -> GHCTargetVersion (lCross lr) (lVer lr)) . lastMay . filter (\lr -> lTool lr == tool)) lInstalled
 
   ghcup <- forMM (getLatest dls GHCup) $ \(GHCTargetVersion _ l, _) -> do

--- a/lib-opt/GHCup/OptParse/List.hs
+++ b/lib-opt/GHCup/OptParse/List.hs
@@ -55,8 +55,8 @@ import GHCup.Prelude.Logger (logDebug)
 
 
 data ListOptions = ListOptions
-  { loTool     :: Maybe Tool
-  , lCriteria  :: Maybe ListCriteria
+  { loTool     :: [Tool]
+  , lCriteria  :: [ListCriteria]
   , lFrom      :: Maybe Day
   , lTo        :: Maybe Day
   , lHideOld   :: Bool
@@ -74,15 +74,15 @@ data ListOptions = ListOptions
 listOpts :: Parser ListOptions
 listOpts =
   ListOptions
-    <$> optional
+    <$> many
           (option
             (eitherReader toolParser)
-            (short 't' <> long "tool" <> metavar "<ghc|cabal|hls|stack>" <> help
+            (short 't' <> long "tool" <> metavar "<ghc|cabal|hls|stack|ghcup>" <> help
               "Tool to list versions for. Default is all"
               <> completer toolCompleter
             )
           )
-    <*> optional
+    <*> many
           (option
             (eitherReader criteriaParser)
             (  short 'c'
@@ -238,7 +238,7 @@ list :: ( Monad m
       -> m ExitCode
 list ListOptions{..} no_color pgc runAppState =
   runAppState (do
-      l <- listVersions loTool (maybeToList lCriteria) lHideOld lShowNightly (lFrom, lTo)
+      l <- listVersions loTool lCriteria lHideOld lShowNightly (lFrom, lTo)
       printListResult no_color pgc lRawFormat l
       pure ExitSuccess
     )

--- a/lib-opt/GHCup/OptParse/Nuke.hs
+++ b/lib-opt/GHCup/OptParse/Nuke.hs
@@ -78,7 +78,7 @@ nuke appState runLogger = do
        lift $ logInfo "Initiating Nuclear Sequence 🚀🚀🚀"
        lift $ logInfo "Nuking in 3...2...1"
 
-       lInstalled <- lift $ listVersions Nothing [ListInstalled True] False True (Nothing, Nothing)
+       lInstalled <- lift $ listVersions [] [ListInstalled True] False True (Nothing, Nothing)
 
        forM_ lInstalled (liftE . rmTool)
 

--- a/lib-tui/GHCup/Brick/Actions.hs
+++ b/lib-tui/GHCup/Brick/Actions.hs
@@ -702,7 +702,7 @@ getAppData mgi = runExceptT $ do
   settings <- liftIO $ readIORef settings'
 
   flip runReaderT settings $ do
-    lV <- listVersions Nothing [] False True (Nothing, Nothing)
+    lV <- listVersions [] [] False True (Nothing, Nothing)
     pure $ BrickData (reverse lV)
 
 --

--- a/lib/GHCup.hs
+++ b/lib/GHCup.hs
@@ -557,7 +557,7 @@ rmUnsetTools :: ( MonadReader env m
                 )
              => Excepts '[NotInstalled, UninstallFailed] m ()
 rmUnsetTools = do
-  vers <- lift $ listVersions Nothing [ListInstalled True, ListSet False] False True (Nothing, Nothing)
+  vers <- lift $ listVersions [] [ListInstalled True, ListSet False] False True (Nothing, Nothing)
   forM_ vers $ \ListResult{..} -> case lTool of
     GHC   -> liftE $ rmGHCVer (GHCTargetVersion lCross lVer)
     HLS   -> liftE $ rmHLSVer lVer

--- a/lib/GHCup/Utils/Parsers.hs
+++ b/lib/GHCup/Utils/Parsers.hs
@@ -174,6 +174,7 @@ toolParser s' | t == T.pack "ghc"   = Right GHC
               | t == T.pack "cabal" = Right Cabal
               | t == T.pack "hls"   = Right HLS
               | t == T.pack "stack" = Right Stack
+              | t == T.pack "ghcup" = Right GHCup
               | otherwise           = Left ("Unknown tool: " <> s')
   where t = T.toLower (T.pack s')
 

--- a/test/optparse-test/ListTest.hs
+++ b/test/optparse-test/ListTest.hs
@@ -11,24 +11,24 @@ listTests :: TestTree
 listTests = buildTestTree listParseWith ("list", listCheckList)
 
 defaultOptions :: ListOptions
-defaultOptions = ListOptions Nothing Nothing Nothing Nothing False False False
+defaultOptions = ListOptions [] [] Nothing Nothing False False False
 
 listCheckList :: [(String, ListOptions)]
 listCheckList =
   [ ("list", defaultOptions)
-  , ("list -t ghc", defaultOptions{loTool = Just GHC})
-  , ("list -t cabal", defaultOptions{loTool = Just Cabal})
-  , ("list -t hls", defaultOptions{loTool = Just HLS})
-  , ("list -t stack", defaultOptions{loTool = Just Stack})
-  , ("list -c installed", defaultOptions{lCriteria = Just $ ListInstalled True})
-  , ("list -c +installed", defaultOptions{lCriteria = Just $ ListInstalled True})
-  , ("list -c -installed", defaultOptions{lCriteria = Just $ ListInstalled False})
-  , ("list -c set", defaultOptions{lCriteria = Just $ ListSet True})
-  , ("list -c +set", defaultOptions{lCriteria = Just $ ListSet True})
-  , ("list -c -set", defaultOptions{lCriteria = Just $ ListSet False})
-  , ("list -c available", defaultOptions{lCriteria = Just $ ListAvailable True})
-  , ("list -c +available", defaultOptions{lCriteria = Just $ ListAvailable True})
-  , ("list -c -available", defaultOptions{lCriteria = Just $ ListAvailable False})
+  , ("list -t ghc", defaultOptions{loTool = [GHC]})
+  , ("list -t cabal", defaultOptions{loTool = [Cabal]})
+  , ("list -t hls", defaultOptions{loTool = [HLS]})
+  , ("list -t stack", defaultOptions{loTool = [Stack]})
+  , ("list -c installed", defaultOptions{lCriteria = [ListInstalled True]})
+  , ("list -c +installed", defaultOptions{lCriteria = [ListInstalled True]})
+  , ("list -c -installed", defaultOptions{lCriteria = [ListInstalled False]})
+  , ("list -c set", defaultOptions{lCriteria = [ListSet True]})
+  , ("list -c +set", defaultOptions{lCriteria = [ListSet True]})
+  , ("list -c -set", defaultOptions{lCriteria = [ListSet False]})
+  , ("list -c available", defaultOptions{lCriteria = [ListAvailable True]})
+  , ("list -c +available", defaultOptions{lCriteria = [ListAvailable True]})
+  , ("list -c -available", defaultOptions{lCriteria = [ListAvailable False]})
   , ("list -s 2023-07-22", defaultOptions{lFrom = Just $ read "2023-07-22"})
   , ("list -u 2023-07-22", defaultOptions{lTo = Just $ read "2023-07-22"})
   , ("list --since 2023-07-22 --until 2023-07-22", defaultOptions{lFrom = Just $ read "2023-07-22", lTo = Just $ read "2023-07-22"})


### PR DESCRIPTION
Fixes #1235

@ulysses4ever 

```
$ ghcup list -t ghc -t cabal -t ghcup -c +installed -c -set
   Tool  Version            Tags                            Notes
✓  ghc   8.6.5              base-4.12.0.0
✓  ghc   8.8.4              base-4.13.0.0
✓  ghc   8.10.7             base-4.14.3.0
✓  ghc   9.2.8              base-4.16.4.0
✓  ghc   9.4.8              recommended,base-4.17.2.1
✓  ghc   9.6.6              base-4.18.2.1
✓  ghc   9.8.0.20230929     prerelease,base-4.19.0.0        2023-09-29
✓  ghc   9.8.4              base-4.19.2.0                   2024-11-27
✓  ghc   9.10.1             base-4.20.0.0
✓  ghc   9.12.0.20241128    latest-prerelease,base-4.21.0.0 2024-11-28
✓  ghc   9.12.1             latest,base-4.21.0.0            2024-12-15
✓  ghc   9.12.1.20250219    latest-prerelease,base-4.21.0.0 2025-02-24
✓  cabal 3.14.1.1           latest
✓  cabal 3.15.0.0.2024.10.3 latest-prerelease
```