### PR TITLE
TUI: allow responding to prompts with Return (defaulting to Yes)

### DIFF
--- a/lib-tui/GHCup/Brick/Actions.hs
+++ b/lib-tui/GHCup/Brick/Actions.hs
@@ -411,7 +411,9 @@ set' input@(_, ListResult {..}) = do
         HLS   -> liftE $ setHLS lVer SetHLSOnly Nothing $> ()
         Stack -> liftE $ setStack lVer $> ()
         GHCup -> do
-          promptAnswer <- getUserPromptResponse "Switching GHCup versions is not supported.\nDo you want to install the latest version? [Y/N]: "
+          promptAnswer <- getUserPromptResponse
+            "Switching GHCup versions is not supported.\nDo you want to install the latest version? [Y/n]: "
+            PromptYes
           case promptAnswer of
                 PromptYes -> do
                   void $ liftE $ upgradeGHCup Nothing False False
@@ -421,7 +423,7 @@ set' input@(_, ListResult {..}) = do
           VRight _ -> pure $ Right ()
           VLeft  e -> case e of
             (V (NotInstalled tool _)) -> do
-              promptAnswer <- getUserPromptResponse userPrompt
+              promptAnswer <- getUserPromptResponse userPrompt PromptYes
               case promptAnswer of
                 PromptYes -> do
                   res <- install' input
@@ -437,7 +439,7 @@ set' input@(_, ListResult {..}) = do
                   "This Version of "
                   <> show tool
                   <> " you are trying to set is not installed.\n"
-                  <> "Would you like to install it first? [Y/N]: "
+                  <> "Would you like to install it first? [Y/n]: "
 
             _ -> pure $ Left (prettyHFError e)
 

--- a/lib/GHCup/Prompts.hs
+++ b/lib/GHCup/Prompts.hs
@@ -9,6 +9,7 @@ module GHCup.Prompts
 where
 
 import Control.Monad.Reader
+import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import GHCup.Prelude.Logger
 import GHCup.Types.Optics
@@ -18,11 +19,14 @@ getUserPromptResponse :: ( HasLog env
                          , MonadReader env m
                          , MonadIO m)
                       => PromptQuestion
+                      -> PromptResponse -- ^ Default reponse to use if user doesn't type explicit response (e.g. just presses Return)
                       -> m PromptResponse
-
-getUserPromptResponse prompt = do
+getUserPromptResponse prompt defaultResponse = do
   logInfo prompt
   resp <- liftIO TIO.getLine
-  if resp `elem` ["YES", "yes", "y", "Y"]
-    then pure PromptYes
-    else pure PromptNo
+  pure $
+    if T.null resp
+      then defaultResponse
+      else if resp `elem` ["YES", "yes", "y", "Y"]
+        then PromptYes
+        else PromptNo


### PR DESCRIPTION
There's this convention in linux CLI tools that if you're asking users for yes/no response, then you highlight the default choice with uppercase (e.g. [Y/n]) and let user stick with the default by just pressing Enter/Return.

This behavior is already present in bunch of places in ghcup installer. Could we please also support this in the prompts used by TUI?
