### PR TITLE
Less confusing choices in bootstrap script for base channel

### DIFF
--- a/scripts/bootstrap/bootstrap-haskell
+++ b/scripts/bootstrap/bootstrap-haskell
@@ -83,6 +83,7 @@ case "${plat}" in
         MSYS*|MINGW*|CYGWIN*)
 			: "${GHCUP_INSTALL_BASE_PREFIX:=/c}"
 			GHCUP_DIR=$(cygpath -u "${GHCUP_INSTALL_BASE_PREFIX}/ghcup")
+			GHCUP_CONFDIR=${GHCUP_DIR}
 			GHCUP_BIN=$(cygpath -u "${GHCUP_INSTALL_BASE_PREFIX}/ghcup/bin")
 			: "${GHCUP_MSYS2:=${GHCUP_DIR}/msys64}"
 			set_msys2_env_dir
@@ -92,9 +93,11 @@ case "${plat}" in
 
 			if [ -n "${GHCUP_USE_XDG_DIRS}" ] ; then
 				GHCUP_DIR=${XDG_DATA_HOME:=$HOME/.local/share}/ghcup
+				GHCUP_CONFDIR=${XDG_DATA_HOME:=$HOME/.config}/ghcup
 				GHCUP_BIN=${XDG_BIN_HOME:=$HOME/.local/bin}
 			else
 				GHCUP_DIR=${GHCUP_INSTALL_BASE_PREFIX}/.ghcup
+				GHCUP_CONFDIR=${GHCUP_DIR}
 				GHCUP_BIN=${GHCUP_INSTALL_BASE_PREFIX}/.ghcup/bin
 			fi
 			;;
@@ -479,16 +482,27 @@ ask_base_channel() {
     warn ""
 	while true; do
 
-        warn "[S] Skip  [D] Default (GHCup maintained)  [V] Vanilla (Upstream maintained)  [?] Help (default is \"Skip\")."
+        if [ "$preexisting_config_file" -eq 1 ] ; then
+            warn "[K] Keep  [G] GHCup maintained  [V] Vanilla (upstream maintained)  [?] Help (default is \"K\")."
+        else
+            warn "[G] GHCup maintained  [V] Vanilla (upstream maintained)  [?] Help (default is \"G\")."
+        fi
         warn ""
 
 		read -r basechannel_answer </dev/tty
 
+        # Handle the [K]eep choice only if we actually offered it
+        if [ "$preexisting_config_file" -eq 1 ] ; then
+            case $basechannel_answer in
+                [Kk]* | "")
+                    return 0
+                    ;;
+            esac
+        fi
+
+        # Handle the other choices
 		case $basechannel_answer in
-			[Ss]* | "")
-				return 0
-				;;
-			[Dd]*)
+			[Gg]* | "")
 				return 1
 				;;
 			[Vv]*)
@@ -497,16 +511,20 @@ ask_base_channel() {
 			*)
 				echo "Possible choices are:"
 				echo
-				echo "[S]kip    - Do nothing and leave GHCup config as is"
-                echo "[D]efault - The default channel maintained by GHCup developers"
+                if [ "$preexisting_config_file" -eq 1 ] ; then
+                    echo "[K]eep    - Do nothing and leave your existing GHCup config as-is"
+                fi
+                echo "[G]HCup   - The default channel maintained by GHCup developers"
                 echo "            (receives QA and support from GHCup and may provide"
                 echo "            unofficial bindists for less supported platforms)"
 				echo "[V]anilla - Only contains unchanged upstream binary distributions"
                 echo "            (is updated with newer releases faster since it receives no GHCup QA)"
 				echo
-				echo "Selecting Default or Vanilla will overwrite any pre-existing channel"
-                echo "config you might have (if you've previously installed GHCup)."
-				echo
+                if [ "$preexisting_config_file" -eq 1 ] ; then
+                    echo "Selecting GHCup or Vanilla will overwrite the channel config in"
+                    echo "your existing GHCup installation."
+                    echo
+                fi
                 echo "Please make your choice and press ENTER."
 				;;
 		esac
@@ -952,6 +970,9 @@ if [ -z "${BOOTSTRAP_HASKELL_NONINTERACTIVE}" ] ; then
     # shellcheck disable=SC2034
     read -r answer </dev/tty
 fi
+
+preexisting_config_file=0
+test -f "${GHCUP_CONFDIR}/config.yaml" && preexisting_config_file=1
 
 edo mkdir -p "${GHCUP_BIN}"
 


### PR DESCRIPTION
The question for the base channel previously unconditionally read as follows:
```
[S] Skip  [D] Default (GHCup maintained)  [V] Vanilla (Upstream maintained)  [?] Help (default is "Skip").
```
For new users, `S` and `D` are equivalent, and this results in a confusing user experience: if they are equivalent, why am I forced to choose anyway? (exhibits: #1278, and [on IRC](https://ircbrowse.tomsmeding.com/day/lchaskell/2025/12/17?id=1720144#trid1720144))

This PR changes the flow to what I described here in https://github.com/haskell/ghcup-hs/issues/1278#issuecomment-3670673949 -- specifically, the version that performs a check for a per-existing config file. If you want simpler code with one global variable less, I would also be fine with amending this PR to my alternative suggestion.

Specifically, the installation experience is changed in the following way by this PR:
1. New users without any pre-existing GHCup installation will not get offered what was previously the [S]kip option, which was functionally identical to [D]efault anyway. (Users with a pre-existing GHCup installation will get offered the same choices as before, albeit renamed.)
2. The [D]efault option is renamed [G]HCup (and [S]kip -> [K]eep). This may mean that Vanilla will get chosen more often, as the GHCup channel may look "less default" than it did before, despite still explicitly being the default option.
3. New users will now always get the prereleases and cross questions, which they previously only got when selecting [S]kip.

As explained, I think that (1.) is clearly a good thing. For (3.), I'm ambivalent: most users won't be interested in the additional channels, but then, I don't think the script should decide whether a user is interested based on whether they choose the apple or the apple.

I'm less sure that (2.) is a good thing. If you think (2.) is sufficiently bad, I'm happy to amend the PR to the simpler alternative, as I said.

The Powershell script doesn't seem to offer this menu so I didn't change it. In separate commits, I also made some minor stylistic changes for better uniformity.