### PR TITLE
Avoid using Alternative unnecessarily

### DIFF
--- a/lib-tui/GHCup/Brick/Actions.hs
+++ b/lib-tui/GHCup/Brick/Actions.hs
@@ -181,7 +181,7 @@ withIOAction action = do
             pure (updateList data' as)
           Left err -> throwIO $ userError err
 
-installWithOptions :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m, Alternative m)
+installWithOptions :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m)
          => AdvancedInstall.InstallOptions
          -> (Int, ListResult)
          -> m (Either String ())
@@ -361,11 +361,11 @@ installWithOptions opts (_, ListResult {..}) = do
           VLeft e -> pure $ Left $ prettyHFError e <> "\n"
             <> "Also check the logs in ~/.ghcup/logs"
 
-install' :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m, Alternative m)
+install' :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m)
          => (Int, ListResult) -> m (Either String ())
 install' = installWithOptions (AdvancedInstall.InstallOptions Nothing False Nothing Nothing False [] "install")
 
-set' :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m, Alternative m)
+set' :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m)
      => (Int, ListResult)
      -> m (Either String ())
 set' input@(_, ListResult {..}) = do
@@ -505,7 +505,7 @@ changelog' (_, ListResult {..}) = do
         Right _ -> pure $ Right ()
         Left  e -> pure $ Left $ prettyHFError e
 
-compileGHC :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m, Alternative m)
+compileGHC :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m)
            => CompileGHC.CompileGHCOptions -> (Int, ListResult) -> m (Either String ())
 compileGHC compopts (_, lr@ListResult{lTool = GHC, ..}) = do
   appstate <- ask
@@ -603,7 +603,7 @@ compileGHC compopts (_, lr@ListResult{lTool = GHC, ..}) = do
 compileGHC _ (_, ListResult{lTool = _}) = pure (Right ())
 
 
-compileHLS :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m, Alternative m)
+compileHLS :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m)
            => CompileHLS.CompileHLSOptions -> (Int, ListResult) -> m (Either String ())
 compileHLS compopts (_, lr@ListResult{lTool = HLS, ..}) = do
   appstate <- ask

--- a/lib/GHCup.hs
+++ b/lib/GHCup.hs
@@ -246,8 +246,7 @@ rmGhcupDirs = do
     ------------------
 
 
-getDebugInfo :: ( Alternative m
-                , MonadFail m
+getDebugInfo :: ( MonadFail m
                 , MonadReader env m
                 , HasDirs env
                 , HasLog env

--- a/lib/GHCup/GHC.hs
+++ b/lib/GHCup/GHC.hs
@@ -533,7 +533,6 @@ installGHCBin :: ( MonadFail m
                  , MonadResource m
                  , MonadIO m
                  , MonadUnliftIO m
-                 , Alternative m
                  )
               => GHCTargetVersion -- ^ the version to install
               -> InstallDir

--- a/lib/GHCup/Platform.hs
+++ b/lib/GHCup/Platform.hs
@@ -71,7 +71,7 @@ import qualified Data.List                     as L
 
 
 -- | Get the full platform request, consisting of architecture, distro, ...
-platformRequest :: (MonadReader env m, Alternative m, MonadFail m, HasLog env, MonadCatch m, MonadIO m)
+platformRequest :: (MonadReader env m, MonadFail m, HasLog env, MonadCatch m, MonadIO m)
                 => Excepts
                      '[NoCompatiblePlatform, NoCompatibleArch, DistroNotFound]
                      m
@@ -96,7 +96,7 @@ getArchitecture = case arch of
   what          -> Left (NoCompatibleArch what)
 
 
-getPlatform :: (Alternative m, MonadReader env m, HasLog env, MonadCatch m, MonadIO m, MonadFail m)
+getPlatform :: (MonadReader env m, HasLog env, MonadCatch m, MonadIO m, MonadFail m)
             => Excepts
                  '[NoCompatiblePlatform, DistroNotFound]
                  m
@@ -136,11 +136,11 @@ getPlatform = do
                                                         Nothing
 
 
-getLinuxDistro :: (Alternative m, MonadCatch m, MonadIO m, MonadFail m)
+getLinuxDistro :: (MonadCatch m, MonadIO m, MonadFail m)
                => Excepts '[DistroNotFound] m (LinuxDistro, Maybe Versioning)
 getLinuxDistro = do
   -- TODO: don't do alternative on IO, because it hides bugs
-  (name, mid, ver) <- handleIO (\_ -> throwE DistroNotFound) $ lift $ asum
+  (name, mid, ver) <- join $ liftIO $ handleIO (\_ -> pure (throwE DistroNotFound)) $ fmap pure $ asum
     [ liftIO try_os_release
     , try_lsb_release_cmd
     , liftIO try_redhat_release

--- a/lib/GHCup/Platform.hs
+++ b/lib/GHCup/Platform.hs
@@ -141,10 +141,10 @@ getLinuxDistro :: (MonadCatch m, MonadIO m, MonadFail m)
 getLinuxDistro = do
   -- TODO: don't do alternative on IO, because it hides bugs
   (name, mid, ver) <- join $ liftIO $ handleIO (\_ -> pure (throwE DistroNotFound)) $ fmap pure $ asum
-    [ liftIO try_os_release
+    [ try_os_release
     , try_lsb_release_cmd
-    , liftIO try_redhat_release
-    , liftIO try_debian_version
+    , try_redhat_release
+    , try_debian_version
     ]
   let hasWord xs = let f t = any (\x -> match (regex x) (T.unpack t)) xs
                    in f name || maybe False f mid


### PR DESCRIPTION
Some were completely redundant, some were just unnecessary with a bit of restructuring. This is also a step towards the TODO in `getLinuxDistro`: "don't do alternative on IO, because it hides bugs".
