### PR TITLE
bump vty: < 6.3 -> < 6.5

### DIFF
--- a/ghcup.cabal
+++ b/ghcup.cabal
@@ -312,7 +312,7 @@ library
 
   if flag(tui)
     cpp-options:   -DBRICK
-    build-depends: vty ^>=6.0 || ^>=6.1 || ^>=6.2
+    build-depends: vty ^>=6.0 || ^>=6.1 || ^>=6.2 || ^>=6.3 || ^>=6.4
 
   if (flag(strict-metadata-parsing))
     cpp-options:     -DSTRICT_METADATA_PARSING
@@ -402,7 +402,7 @@ library ghcup-tui
   build-depends:
     , ghcup
     , brick         >=2.1 && <2.11
-    , vty           ^>=6.0 || ^>=6.1 || ^>=6.2
+    , vty           ^>=6.0 || ^>=6.1 || ^>=6.2 || ^>=6.3 || ^>=6.4
 
   if !flag(tui)
     buildable: False


### PR DESCRIPTION
ghcup builds with vty 6.4. (NixOS WSL x86-64)

Nix build automatically runs unit tests, so those have passed with the build. 