### PR TITLE
Docs: clarify BOOTSTRAP_HASKELL_NONINTERACTIVE uses non-empty value

### DIFF
--- a/scripts/bootstrap/bootstrap-haskell
+++ b/scripts/bootstrap/bootstrap-haskell
@@ -5,7 +5,7 @@
 # that affect the installation procedure.
 
 # Main settings:
-#   * BOOTSTRAP_HASKELL_NONINTERACTIVE - any nonzero value for noninteractive installation
+#   * BOOTSTRAP_HASKELL_NONINTERACTIVE - any non-empty value for noninteractive installation
 #   * BOOTSTRAP_HASKELL_NO_UPGRADE - any nonzero value to not trigger the upgrade
 #   * BOOTSTRAP_HASKELL_MINIMAL - any nonzero value to only install ghcup
 #   * GHCUP_USE_XDG_DIRS - any nonzero value to respect The XDG Base Directory Specification


### PR DESCRIPTION
This PR updates the documentation/comment to clarify that BOOTSTRAP_HASKELL_NONINTERACTIVE checks for a non-empty value rather than a non-zero value, as discussed in the issue.
Closes #1295
