### PR TITLE
refactor!: store log files under XDG_STATE_HOME instead of XDG_CACHE_HOME when following XDG style

### DIFF
--- a/lib-tui/GHCup/Brick/Actions.hs
+++ b/lib-tui/GHCup/Brick/Actions.hs
@@ -308,7 +308,7 @@ installWithOptions opts (_, ListResult {..}) = do
           VLeft  (V (AlreadyInstalled _ _)) -> pure $ Right ()
           VLeft (V NoUpdate) -> pure $ Right ()
           VLeft e -> pure $ Left $ prettyHFError e <> "\n"
-            <> "Also check the logs in ~/.ghcup/logs or $XDG_CACHE_HOME/ghcup/logs"
+            <> "Also check the logs in ~/.ghcup/logs or $XDG_STATE_HOME/ghcup/logs"
 
 install' :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m, Alternative m)
          => (Int, ListResult) -> m (Either String ())

--- a/lib-tui/GHCup/Brick/Actions.hs
+++ b/lib-tui/GHCup/Brick/Actions.hs
@@ -308,7 +308,7 @@ installWithOptions opts (_, ListResult {..}) = do
           VLeft  (V (AlreadyInstalled _ _)) -> pure $ Right ()
           VLeft (V NoUpdate) -> pure $ Right ()
           VLeft e -> pure $ Left $ prettyHFError e <> "\n"
-            <> "Also check the logs in ~/.ghcup/logs"
+            <> "Also check the logs in ~/.ghcup/logs or $XDG_CACHE_HOME/ghcup/logs"
 
 install' :: (MonadReader AppState m, MonadIO m, MonadThrow m, MonadFail m, MonadMask m, MonadUnliftIO m, Alternative m)
          => (Int, ListResult) -> m (Either String ())

--- a/lib/GHCup/Query/GHCupDirs.hs
+++ b/lib/GHCup/Query/GHCupDirs.hs
@@ -232,7 +232,7 @@ ghcupCacheDir
 -- | Defaults to '~/.ghcup/logs'.
 --
 -- If 'GHCUP_USE_XDG_DIRS' is set (to anything),
--- then uses 'XDG_CACHE_HOME/ghcup/logs' as per xdg spec.
+-- then uses 'XDG_STATE_HOME/ghcup/logs' as per xdg spec.
 ghcupLogsDir :: IO GHCupPath
 ghcupLogsDir
   | isWindows = ghcupBaseDir <&> (\(GHCupPath gp) -> GHCupPath (gp </> "logs"))
@@ -240,11 +240,11 @@ ghcupLogsDir
       xdg <- useXDG
       if xdg
         then do
-          bdir <- lookupEnv "XDG_CACHE_HOME" >>= \case
+          bdir <- lookupEnv "XDG_STATE_HOME" >>= \case
             Just r  -> pure r
             Nothing -> do
               home <- liftIO getHomeDirectory
-              pure (home </> ".cache")
+              pure (home </> ".local" </> "state")
           pure (GHCupPath (bdir </> "ghcup" </> "logs"))
         else ghcupBaseDir <&> (\(GHCupPath gp) -> GHCupPath (gp </> "logs"))
 


### PR DESCRIPTION
- [x] I have read https://www.haskell.org/ghcup/dev/
- [x] I did not use an LLM to generate this patch or parts of it

<https://specifications.freedesktop.org/basedir/0.8/#variables>

Also modify message to indicate log file location when following XDG style.