### PR TITLE
Tweak prettyRequirements to put pkg names on own line.

### DIFF
--- a/lib/GHCup/Requirements.hs
+++ b/lib/GHCup/Requirements.hs
@@ -63,6 +63,7 @@ prettyRequirements Requirements {..} =
         then "\n  Please ensure the following distro packages "
           <> "are installed before continuing (you can exit ghcup "
           <> "and return at any time): "
+          <> "\n    "
           <> T.intercalate " " _distroPKGs
         else ""
       n = if not . T.null $ _notes then "\n  Note: " <> _notes else ""


### PR DESCRIPTION
- [x] I have read https://www.haskell.org/ghcup/dev/
- [x] I did not use an LLM to generate this patch or parts of it

Makes it easier to copy the package list by double click.
