### PR TITLE
Add test for install targets

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -156,6 +156,17 @@ if [ "${OS}" = "Windows" ] ; then
 	eghcup run -m -- sh -c 'echo $PATH' | sed 's/:/\n/' | grep '^/clang64/bin$'
 fi
 
+# test install targets
+eghcup install ghc --install-targets "install_bin install_lib update_package_db install_extra" "9.10.3"
+eghcup set ghc "9.10.3"
+eghcup unset ghc
+ls -lah "$(eghcup whereis -d ghc "9.10.3")"
+[ "$($(eghcup whereis ghc "9.10.3") --numeric-version)" = "9.10.3" ]
+[ "$(eghcup run -q --ghc "9.10.3" -- ghc --numeric-version)" = "9.10.3" ]
+[ "$(ghcup run -q --ghc "9.10.3" -- ghc -e 'Control.Monad.join (Control.Monad.fmap System.IO.putStr System.Environment.getExecutablePath)')" = "$($(ghcup whereis ghc "9.10.3") -e 'Control.Monad.join (Control.Monad.fmap System.IO.putStr System.Environment.getExecutablePath)')" ]
+eghcup rm ghc "9.10.3"
+
+# normal
 eghcup install ghc "${GHC_VER}"
 eghcup set ghc "${GHC_VER}"
 eghcup unset ghc
@@ -164,6 +175,7 @@ ls -lah "$(eghcup whereis -d ghc "${GHC_VER}")"
 [ "$(eghcup run -q --ghc "${GHC_VER}" -- ghc --numeric-version)" = "${GHC_VER}" ]
 [ "$(ghcup run -q --ghc "${GHC_VER}" -- ghc -e 'Control.Monad.join (Control.Monad.fmap System.IO.putStr System.Environment.getExecutablePath)')" = "$($(ghcup whereis ghc "${GHC_VER}") -e 'Control.Monad.join (Control.Monad.fmap System.IO.putStr System.Environment.getExecutablePath)')" ]
 eghcup set ghc "${GHC_VER}"
+
 eghcup install cabal "${CABAL_VER}"
 [ "$($(eghcup whereis cabal "${CABAL_VER}") --numeric-version)" = "${CABAL_VER}" ]
 eghcup unset cabal


### PR DESCRIPTION
- [ ] I have read https://www.haskell.org/ghcup/dev/
- [ ] I did not use an LLM to generate this patch or parts of it

----

Overwriting install targets via e.g. `ghcup install ghc --install-targets "install_bin install_lib update_package_db install_extra" 9.10.3` will silently drop `DESTDIR=/some/ghcup/tmp/dir`, causing install failure.

The solution is to move DESTDIR to the `EnvSpec` as to allow users to overwrite install targets in a simple fashion.

First seen in https://github.com/haskell/cabal/actions/runs/26255587728/job/77286948602#step:5:1581

Error was:

```
2026-05-21T23:17:12.0968729Z [6A[0J[1m[91m[ Error ][0m[0m []8;;https://errors.haskell.org/messages/GHCup-00080\GHCup-00080]8;;\] Unmet precondition for merging file tree from /github/home/.ghcup/tmp/ghcup-00a68255c06ba0a6/github/home/.ghcup/ghc/9.10.3 to /github/home/.ghcup/ghc/9.10.3 
2026-05-21T23:17:12.0970284Z [1m[91m[ ...   ] [0m[0mexception was: user error (mergeFileTree: source base directory /github/home/.ghcup/tmp/ghcup-00a68255c06ba0a6/github/home/.ghcup/ghc/9.10.3 does not exist!)
2026-05-21T23:17:12.0971086Z [1m[91m[ Error ][0m[0m Also check the logs in /github/home/.ghcup/logs
```