### PR TITLE
Fix 'ghcup whereis' on unknown tool versions

### DIFF
--- a/lib/GHCup/Command/Whereis.hs
+++ b/lib/GHCup/Command/Whereis.hs
@@ -66,14 +66,15 @@ whereIsTool :: ( MonadReader env m
                )
             => Tool
             -> TargetVersion
-            -> Excepts '[NotInstalled, ParseError, NoInstallInfo] m FilePath
+            -> Excepts '[NotInstalled] m FilePath
 whereIsTool tool ver@TargetVersion {..} = do
   dirs <- lift getDirs
-  sSpec <- lift $ getSymlinkSpecPortable tool ver
   toolDir <- fromGHCupPath <$> lift (toolInstallDestination tool ver)
 
+  sSpec <- runE $ getSymlinkSpec tool ver
+
   case sSpec of
-    (SymlinkSpec{..}:_) ->
+    (VRight (SymlinkSpec{..}:_)) ->
       pure $ toolDir </> _slTarget
     _ ->
       case tool of
@@ -102,6 +103,5 @@ whereIsTool tool ver@TargetVersion {..} = do
         Tool "ghcup" -> do
           currentRunningExecPath <- liftIO getExecutablePath
           liftIO $ canonicalizePath currentRunningExecPath
-        -- TODO
-        _ -> pure ""
+        _ -> throwE (NotInstalled tool ver)
 

--- a/lib/GHCup/Errors.hs
+++ b/lib/GHCup/Errors.hs
@@ -436,6 +436,8 @@ instance HFErrorProject NotInstalled where
   eBase _ = 130
   eDesc _ = "The required tool is not installed"
 
+instance Exception NotInstalled
+
 data UninstallFailed = UninstallFailed FilePath [FilePath]
   deriving (Show)
 

--- a/lib/GHCup/Query/DB/HLS.hs
+++ b/lib/GHCup/Query/DB/HLS.hs
@@ -5,6 +5,7 @@
 module GHCup.Query.DB.HLS where
 
 import GHCup.Legacy.Utils
+import GHCup.Prelude (isWindows)
 import GHCup.Query.DB
 import GHCup.Types
 import GHCup.Types.Optics
@@ -34,7 +35,9 @@ getHLSGHCs hlsVer = do
       let extractGHCVerFromBinary (stripExe -> bin) = do
             prefix <- splitIt '~' bin
             s <- stripPrefix "haskell-language-server-" prefix
-            either (const Nothing) pure . version . T.pack $ s
+            -- stripExe here because we might have a binary of the form
+            -- haskell-language-server-9.12.2.exe~2.14.0.0
+            either (const Nothing) pure . version . T.pack . stripExe $ s
           ghcs = catMaybes $ extractGHCVerFromBinary <$> bins
       pure ghcs
     -- legacy
@@ -48,6 +51,8 @@ getHLSGHCs hlsVer = do
       | otherwise = go (prefix <> [x]) xs
     go _ [] = Nothing
 
-  stripExe f = case reverse f of
-                 ('e':'x':'e':'.':r) -> reverse r
-                 _ -> f
+  stripExe f
+    | isWindows = case reverse f of
+                    ('e':'x':'e':'.':r) -> reverse r
+                    _ -> f
+    | otherwise = f


### PR DESCRIPTION
Fixes #1347

- [x] I have read https://www.haskell.org/ghcup/dev/
- [x] I did not use an LLM to generate this patch or parts of it
