### PR TITLE
Report proper tool name when using --isolate option

### DIFF
--- a/lib/GHCup/Command/Install.hs
+++ b/lib/GHCup/Command/Install.hs
@@ -178,7 +178,7 @@ installBindist tool toolDesc dlinfo trev@(TargetVersionRev tver rev) installDir 
 
   case installDir of
     IsolateDir isoDir -> do             -- isolated install
-      lift $ logInfo $ "isolated installing Cabal to " <> T.pack isoDir
+      lift $ logInfo $ T.pack $ "isolated installing " <> prettyShow tool <> " to " <> isoDir
       installSpec <- liftE $ installPackedBindist tool toolDesc dl dlinfo (IsolateDirResolved isoDir) trev forceInstall extraArgs installTargets
       pure (installSpec, isoDir)
 


### PR DESCRIPTION
At the moment, every time we use `--isolate` option, we have log messages like those ones:
```shell
$ ghcup install cabal --isolate /opt/ghc/bin --force 3.16.1.0
[ Info  ] isolated installing Cabal to /opt/ghc/bin
[ Info  ] cabal installation successful
$ ghcup install ghc --isolate /opt/ghc --force 9.12.4
[ Info  ] isolated installing Cabal to /opt/ghc
[ Info  ] ghc installation successful
```

I suppose it would make sense to use the message `isolated installing` followed by the tool name.

- [x] I have read https://www.haskell.org/ghcup/dev/
- [x] I did not use an LLM to generate this patch or parts of it
