### PR TITLE
Add cabal-gild to cabalBadNames

### DIFF
--- a/lib/GHCup/Types/JSON.hs
+++ b/lib/GHCup/Types/JSON.hs
@@ -128,6 +128,7 @@ cabalBadNames =
   , "edit"
   , "env"
   , "fmt"
+  , "gild"
   , "haddock-server"
   , "hasklint"
   , "helper"


### PR DESCRIPTION
- [X] I have read https://www.haskell.org/ghcup/dev/
- [X] I did not use an LLM to generate this patch or parts of it

Resolves https://github.com/haskell/ghcup-hs/issues/1374 - `cabal-gild` is no longer erroneously considered a version of `cabal`.